### PR TITLE
Add support for detecting bright nanoparticles on dark background

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ It supports both **single-image** and **batch image** analysis, providing a modu
 ---
 
 ## Features
+- Supports nanoparticle detection for both contrast polarities:
+  - dark particles on light background
+  - bright particles on dark background (via `--bright-particles` flag)
 - Automated **scale bar & text exclusion** from images
 - **Manual calibration mode** for images without scale bars (direct nm/pixel input)
 - **Particle segmentation** using classical methods (Otsu thresholding, preprocessing filters)
@@ -501,6 +504,16 @@ python3 nanopsd.py --mode batch --input ./images --algo classical --min-size 3 -
 
 ---
 
+### Contrast Polarity Option
+
+By default, NanoPSD assumes nanoparticles appear darker than the background (dark-on-light contrast), which is common in electron microscopy images.
+
+If nanoparticles appear brighter than the background (light-on-dark contrast), use the `--bright-particles` flag:
+
+```bash
+nanopsd input_image.png --bright-particles
+```
+
 ### Single Image Analysis
 
 **Recommended (with manual scale):**
@@ -595,6 +608,7 @@ batch_images/
 | `--max-size`        | Maximum particle size (pixels)                   | `--max-size 200`         | No       |
 | `--save-preprocessing-steps` | Save step-by-step preprocessing images | `--save-preprocessing-steps` | No  |
 | `--save-segmentation-steps`  | Save step-by-step segmentation images  | `--save-segmentation-steps`  | No  |
+|  `--bright-particles` | Detect bright nanoparticles on dark background | `--bright-particles` | No  |
 
 \* **Must provide either `--scale-bar-nm` OR `--nm-per-pixel` (not both)**
 

--- a/nanopsd.py
+++ b/nanopsd.py
@@ -257,6 +257,7 @@ def main() -> None:
         verify_scale_bar=args.verify_scale_bar,  # Enable manual verification of scale detection
         save_preprocessing_steps=args.save_preprocessing_steps,
         save_segmentation_steps=args.save_segmentation_steps,
+        bright_particles=args.bright_particles,
         # Morphology classification thresholds
         spherical_ar_max=thresholds["spherical_ar_max"],
         rodlike_ar_min=thresholds["rodlike_ar_min"],

--- a/pipeline/analyzer.py
+++ b/pipeline/analyzer.py
@@ -140,6 +140,7 @@ class NanoparticleAnalyzer:
         nm_per_pixel: float = None,  # Adding capability to directly input nm_per_pixel
         save_preprocessing_steps: bool = False,
         save_segmentation_steps: bool = False,
+        bright_particles: bool = False,
         # Morphology classification thresholds
         spherical_ar_max=1.5,
         rodlike_ar_min=1.8,
@@ -222,6 +223,7 @@ class NanoparticleAnalyzer:
         self.nm_per_pixel_manual = nm_per_pixel  # Direct nm/pixel input
         self.save_preprocessing_steps = save_preprocessing_steps
         self.save_segmentation_steps = save_segmentation_steps
+        self.bright_particles = bright_particles
 
         # Store results for batch aggregation
         self.batch_results = []  # Will hold DataFrames from each image
@@ -543,6 +545,7 @@ class NanoparticleAnalyzer:
                     if hasattr(self, "save_preprocessing_steps")
                     else False
                 ),
+                bright_particles=self.bright_particles,
             )
 
             # -----------------------------------------------------------------

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -370,6 +370,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    p.add_argument(
+        "--bright-particles",
+        action="store_true",
+        help=(
+            "Use when particles are BRIGHT on a DARK background.\n"
+            "Default behavior assumes dark particles on light background.\n"
+            "Example: bright spheres on dark TEM background."
+        ),
+    )
+
     # ============================================================================
     # Optional: Morphology Classification Thresholds
     # ============================================================================

--- a/scripts/preprocessing/clahe_filter.py
+++ b/scripts/preprocessing/clahe_filter.py
@@ -22,7 +22,7 @@ import os
 
 
 def preprocess_image(
-    image_path, save_steps=False, output_dir="outputs/preprocessing_steps"
+    image_path, save_steps=False, output_dir="outputs/preprocessing_steps", bright_particles=False
 ):
     """
     Preprocesses a microscopy image by enhancing contrast, smoothing, and thresholding.
@@ -85,8 +85,9 @@ def preprocess_image(
         cv2.imwrite(f"{output_dir}/{base_name}_step5_otsu_threshold.png", binary)
         print(f"Saved: {output_dir}/{base_name}_step5_otsu_threshold.png")
 
-    # Step 6: Invert the binary image
-    binary = 255 - binary
+    # Step 6: Invert the binary image (skip if bright particles)
+    if not bright_particles:
+        binary = 255 - binary
 
     if save_steps:
         cv2.imwrite(f"{output_dir}/{base_name}_step6_inverted.png", binary)


### PR DESCRIPTION
This PR adds support for detecting nanoparticles that appear brighter than the background (light-on-dark contrast) through a new command-line flag:
`--bright-particles`
Previously, NanoPSD assumed nanoparticles appear darker than the background (dark-on-light contrast), which is typical for many electron microscopy images. However, in several electron microscopy modalities — such as TEM, HAADF-STEM, or inverted contrast datasets — nanoparticles often appear brighter than the surrounding background.

This enhancement extends the segmentation pipeline to support both contrast polarities, improving the robustness and general applicability of NanoPSD across a wider range of imaging conditions.