### PR TITLE
Fix inconsistent size filtering between segmentation and measurement pipeline

### DIFF
--- a/scripts/segmentation/otsu_segment.py
+++ b/scripts/segmentation/otsu_segment.py
@@ -73,7 +73,8 @@ def segment_particles(
     # Step 2: Remove small objects from the binary image
     # This is a morphological operation to eliminate noise and tiny specks
     # Any connected group of True pixels smaller than min_size is removed
-    cleaned = morphology.remove_small_objects(binary_image, min_size=min_size)
+    min_area = int(np.pi * (min_size / 2) ** 2)  # Convert min_size (diameter) to area for circular approximation
+    cleaned = morphology.remove_small_objects(binary_image, min_size=min_area)
 
     if save_steps:
         cleaned_vis = (cleaned * 255).astype(np.uint8)
@@ -91,7 +92,8 @@ def segment_particles(
         # Create mask excluding large objects
         mask = np.ones_like(cleaned, dtype=bool)
         for region in temp_regions:
-            if region.area > max_size:
+            max_area = int(np.pi * (max_size / 2) ** 2)  # Convert max_size (diameter) to area for circular approximation
+            if region.area > max_area:
                 mask[temp_labeled == region.label] = False
 
         cleaned = cleaned & mask


### PR DESCRIPTION
Fix inconsistent interpretation of `--min-size` and `--max-size` between segmentation and measurement modules.

Previously, otsu_segment.py passed min_size directly to remove_small_objects, which interprets the value as area in pixels. However, size_measurement.py interprets the same parameter as particle diameter and converts it to area.

This PR ensures consistent interpretation of size parameters as particle diameter across the entire pipeline by converting diameter to area before applying segmentation filtering.

This results in predictable and scientifically consistent size filtering behavior.