### PR TITLE
Support morphology-specific result filtering via CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It supports both **single-image** and **batch image** analysis, providing a modu
 - **Flexible particle filtering** with `--min-size` and `--max-size` (removes noise and false detections)
 - **Pipeline visualization** for papers and presentations (`--save-preprocessing-steps`, `--save-segmentation-steps`)
 - **Morphology-based nanoparticle classification** (spherical, rod-like, aggregate)
+- **Morphology filtering** via `--only-morphology` (analyze only spherical, rod-like, or aggregate)
 - **Customizable morphology thresholds** via optional CLI flags
 - **Publication-quality plots** with enhanced font sizes and statistics
 - **Comprehensive shape analysis** (aspect ratio, circularity, solidity distributions)
@@ -514,6 +515,24 @@ If nanoparticles appear brighter than the background (light-on-dark contrast), u
 nanopsd input_image.png --bright-particles
 ```
 
+### Morphology Filtering
+
+To analyze only a specific particle type, use `--only-morphology`:
+
+```bash
+# Only spherical particles
+python3 nanopsd.py --mode single --input sample.tif --scale-bar-nm 200 --algo classical --min-size 3 --only-morphology spherical
+
+# Only rod-like particles
+python3 nanopsd.py --mode single --input sample.tif --scale-bar-nm 200 --algo classical --min-size 3 --only-morphology rod-like
+
+# Only aggregates
+python3 nanopsd.py --mode single --input sample.tif --scale-bar-nm 200 --algo classical --min-size 3 --only-morphology aggregate
+```
+
+When active, all outputs (contour overlays, morphology overlay, histograms, CSV, and statistics) will only include the selected particle type.
+
+
 ### Single Image Analysis
 
 **Recommended (with manual scale):**
@@ -609,6 +628,7 @@ batch_images/
 | `--save-preprocessing-steps` | Save step-by-step preprocessing images | `--save-preprocessing-steps` | No  |
 | `--save-segmentation-steps`  | Save step-by-step segmentation images  | `--save-segmentation-steps`  | No  |
 |  `--bright-particles` | Detect bright nanoparticles on dark background | `--bright-particles` | No  |
+| `--only-morphology` | Only report results for a specific morphology type | `--only-morphology spherical` | No |
 
 \* **Must provide either `--scale-bar-nm` OR `--nm-per-pixel` (not both)**
 

--- a/nanopsd.py
+++ b/nanopsd.py
@@ -266,6 +266,8 @@ def main() -> None:
         rodlike_s_min=thresholds["rodlike_s_min"],
         aggregate_s_max=thresholds["aggregate_s_max"],
         spherical_s_min=thresholds["spherical_s_min"],
+        # Morphology filtering
+        only_morphology=args.only_morphology,
     )
 
     # -------------------------------------------------------------------------

--- a/pipeline/analyzer.py
+++ b/pipeline/analyzer.py
@@ -142,6 +142,7 @@ class NanoparticleAnalyzer:
         save_preprocessing_steps: bool = False,
         save_segmentation_steps: bool = False,
         bright_particles: bool = False,
+        only_morphology: str = None,
         # Morphology classification thresholds
         spherical_ar_max=1.5,
         rodlike_ar_min=1.8,
@@ -225,6 +226,7 @@ class NanoparticleAnalyzer:
         self.save_preprocessing_steps = save_preprocessing_steps
         self.save_segmentation_steps = save_segmentation_steps
         self.bright_particles = bright_particles
+        self.only_morphology = only_morphology  # Store morphology filtering option
 
         # Store results for batch aggregation
         self.batch_results = []  # Will hold DataFrames from each image
@@ -640,6 +642,7 @@ class NanoparticleAnalyzer:
                 aggregate_c_max=self.aggregate_c_max,
                 rodlike_ar_min=self.rodlike_ar_min,
                 rodlike_s_min=self.rodlike_s_min,
+                only_morphology=self.only_morphology,
             )
             logging.info(f"Measured {len(diameters_nm)} particles (post-filter).")
 

--- a/scripts/analysis/size_measurement.py
+++ b/scripts/analysis/size_measurement.py
@@ -24,7 +24,7 @@ import cv2
 import matplotlib.pyplot as plt
 from skimage.draw import ellipse_perimeter
 
-CONTOUR_THICKNESS = 1  # Thickness of contour lines when drawing
+CONTOUR_THICKNESS = 5  # Thickness of contour lines when drawing
 
 
 def measure_particles(
@@ -35,6 +35,7 @@ def measure_particles(
     image_path,
     min_size_px=5,
     max_size_px=None,
+    only_morphology=None,
     # Morphology classification thresholds
     spherical_ar_max=1.5,
     spherical_c_min=0.75,
@@ -110,59 +111,15 @@ def measure_particles(
             # Create a binary mask for the current region
             # 'labeled == region.label' will be True for pixels belonging to this region
             # Convert boolean mask to uint8 (0 or 1) so OpenCV can process it
+            
             region_mask = (labeled_image == region.label).astype(np.uint8)
 
-            # --- 1. True Contour (in BLUE) ---
-            # Find contours in the binary mask
-            # Since we're looking at one particle at a time, there should typically be just one contour
-            # cv2.RETR_EXTERNAL: retrieve only outer contours (ignores internal holes)
-            # cv2.CHAIN_APPROX_SIMPLE: compresses contour points (saves memory)
-            contours, _ = cv2.findContours(
-                region_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
-            )
-            # Draw the contours on the image
-            # -1 indicates all contours found
-            # (0, 0, 255) sets the contour color to red (in BGR format)
-            # Thickness of 1 pixel
-            cv2.drawContours(
-                true_contour_img, contours, -1, (255, 0, 0), CONTOUR_THICKNESS
-            )
-            cv2.drawContours(combined_img, contours, -1, (255, 0, 0), CONTOUR_THICKNESS)
-
-            # --- 2. Circular Equivalent Contour (in RED) ---
-            d_px = region.equivalent_diameter
-            y, x = region.centroid
-            rr, cc = ellipse_perimeter(int(y), int(x), int(d_px / 2), int(d_px / 2))
-            rr = np.clip(rr, 0, original_image.shape[0] - 1)
-            cc = np.clip(cc, 0, original_image.shape[1] - 1)
-            circular_img[rr, cc] = (0, 0, 255)
-            combined_img[rr, cc] = (0, 0, 255)
-
-            # --- 3. Elliptical Equivalent Contour (in PINK) ---
-            for contour in contours:
-                if len(contour) >= 5:
-                    ellipse = cv2.fitEllipse(contour)
-                    # Validate ellipse dimensions before drawing
-                    (center, axes, angle) = ellipse
-                    if (
-                        axes[0] > 0 and axes[1] > 0
-                    ):  # Check width and height are positive
-                        cv2.ellipse(
-                            elliptical_img, ellipse, (255, 0, 255), CONTOUR_THICKNESS
-                        )
-                        cv2.ellipse(
-                            combined_img, ellipse, (255, 0, 255), CONTOUR_THICKNESS
-                        )
-
-            # Morphology Classification
-            # Calculate shape metrics
-            # Smooth the region mask to reduce boundary noise
+            # --- Classify morphology FIRST ---
             kernel_size = max(3, int(np.sqrt(region.area) * 0.1) // 2 * 2 + 1)
             kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (kernel_size, kernel_size))
             smoothed_mask = cv2.morphologyEx(region_mask, cv2.MORPH_CLOSE, kernel)
             smoothed_mask = cv2.morphologyEx(smoothed_mask, cv2.MORPH_OPEN, kernel)
 
-            # Recalculate shape metrics from smoothed contour
             smooth_contours, _ = cv2.findContours(smoothed_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
             if smooth_contours:
                 smooth_cnt = max(smooth_contours, key=cv2.contourArea)
@@ -173,11 +130,9 @@ def measure_particles(
                 smooth_area = region.area
 
             if len(region.coords) >= 5:
-                # Get perimeter (already calculated earlier but need it here too)
                 major_axis = region.major_axis_length
                 minor_axis = region.minor_axis_length
                 aspect_ratio = major_axis / max(minor_axis, 1e-6)
-
                 circularity = (4 * np.pi * smooth_area) / max(perimeter**2, 1e-6)
                 if smooth_contours:
                     hull = cv2.convexHull(smooth_cnt)
@@ -187,8 +142,6 @@ def measure_particles(
                     solidity = region.solidity
                 extent = region.extent
 
-                # Classification logic (priority: aggregate > spherical > rod-like)
-                # Using configurable thresholds
                 if solidity < aggregate_s_max or circularity < aggregate_c_max:
                     morphology = "aggregate"
                 elif (
@@ -208,8 +161,42 @@ def measure_particles(
                 extent = 1.0
                 morphology = "aggregate"
 
-            # Add the diameter to the result list
-            # Store all measurements in lists
+            # --- Skip if doesn't match filter ---
+            if only_morphology is not None and morphology != only_morphology:
+                continue
+
+            # --- 1. True Contour (in BLUE) ---
+            contours, _ = cv2.findContours(
+                region_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+            )
+            cv2.drawContours(
+                true_contour_img, contours, -1, (255, 0, 0), CONTOUR_THICKNESS
+            )
+            cv2.drawContours(combined_img, contours, -1, (255, 0, 0), CONTOUR_THICKNESS)
+
+            # --- 2. Circular Equivalent Contour (in RED) ---
+            d_px = region.equivalent_diameter
+            y, x = region.centroid
+            rr, cc = ellipse_perimeter(int(y), int(x), int(d_px / 2), int(d_px / 2))
+            rr = np.clip(rr, 0, original_image.shape[0] - 1)
+            cc = np.clip(cc, 0, original_image.shape[1] - 1)
+            circular_img[rr, cc] = (0, 0, 255)
+            combined_img[rr, cc] = (0, 0, 255)
+
+            # --- 3. Elliptical Equivalent Contour (in PINK) ---
+            for contour in contours:
+                if len(contour) >= 5:
+                    ellipse = cv2.fitEllipse(contour)
+                    (center, axes, angle) = ellipse
+                    if axes[0] > 0 and axes[1] > 0:
+                        cv2.ellipse(
+                            elliptical_img, ellipse, (255, 0, 255), CONTOUR_THICKNESS
+                        )
+                        cv2.ellipse(
+                            combined_img, ellipse, (255, 0, 255), CONTOUR_THICKNESS
+                        )
+
+            # --- Store measurements ---
             diameters_pixels.append(d_px)
             diameters_nm.append(d_nm)
             centroids.append(
@@ -292,35 +279,56 @@ def measure_particles(
 
             region_idx += 1
 
-    # Add legend
-    legend_y = 60
-    cv2.putText(
-        morphology_overlay,
-        "Green = Spherical",
-        (15, legend_y),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        2.0,
-        (0, 100, 0),
-        5,
-    )
-    cv2.putText(
-        morphology_overlay,
-        "Blue = Rod-like",
-        (15, legend_y + 60),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        2.0,
-        (255, 0, 0),
-        5,
-    )
-    cv2.putText(
-        morphology_overlay,
-        "Red = Aggregate",
-        (15, legend_y + 120),
-        cv2.FONT_HERSHEY_SIMPLEX,
-        2.0,
-        (0, 0, 255),
-        5,
-    )
+    # # Add legend
+    # legend_y = 60
+    # cv2.putText(
+    #     morphology_overlay,
+    #     "Green = Spherical",
+    #     (15, legend_y),
+    #     cv2.FONT_HERSHEY_SIMPLEX,
+    #     2.0,
+    #     (0, 100, 0),
+    #     5,
+    # )
+    # cv2.putText(
+    #     morphology_overlay,
+    #     "Blue = Rod-like",
+    #     (15, legend_y + 60),
+    #     cv2.FONT_HERSHEY_SIMPLEX,
+    #     2.0,
+    #     (255, 0, 0),
+    #     5,
+    # )
+    # cv2.putText(
+    #     morphology_overlay,
+    #     "Red = Aggregate",
+    #     (15, legend_y + 120),
+    #     cv2.FONT_HERSHEY_SIMPLEX,
+    #     2.0,
+    #     (0, 0, 255),
+    #     5,
+    # )
+
+    # Add legend (only for morphologies present in results)
+    legend_items = [
+        ("Spherical", (0, 100, 0), "spherical"),
+        ("Rod-like", (255, 0, 0), "rod-like"),
+        ("Aggregate", (0, 0, 255), "aggregate"),
+    ]
+    morph_types = [c["morphology"] for c in centroids]
+    legend_y = 120
+    for text, color, morph in legend_items:
+        if morph in morph_types:
+            cv2.putText(
+                morphology_overlay,
+                text,
+                (15, legend_y),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                3.0,
+                color,
+                8,
+            )
+            legend_y += 100
 
     # Save morphology overlay
     morph_path = f"outputs/figures/{stem}_morphology_overlay{ext}"

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -380,6 +380,18 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    p.add_argument(
+        "--only-morphology",
+        default=None,
+        choices=["spherical", "rod-like", "aggregate"],
+        metavar="TYPE",
+        help=(
+            "Only report results for a specific morphology type.\n"
+            "Choices: spherical, rod-like, aggregate\n"
+            "Example: --only-morphology spherical"
+        ),
+    )    
+
     # ============================================================================
     # Optional: Morphology Classification Thresholds
     # ============================================================================


### PR DESCRIPTION
Summary
This PR adds support for restricting NanoPSD output to a specific particle morphology class using command-line flags.

New options:
```
--only-morphology spherical
--only-morphology rod-like
--only-morphology aggregate
```
When specified, NanoPSD performs detection and classification as usual but filters final results to include only the selected morphology class.