### PR TITLE
Add --interactive-roi flag for user-selected analysis regions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,8 @@ Thumbs.db
 *.pdf
 # Keep sample reports
 !example_report.pdf
+
+# ----------------------------
+# Interactive ROI cache (temporary cropped images)
+# ----------------------------
+outputs/.cache/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It supports both **single-image** and **batch image** analysis, providing a modu
   - bright particles on dark background (via `--bright-particles` flag)
 - Automated **scale bar & text exclusion** from images
 - **Manual calibration mode** for images without scale bars (direct nm/pixel input)
+- **Interactive ROI selection** (`--interactive-roi`) for analyzing only part of an image
 - **Particle segmentation** using classical methods (Otsu thresholding, preprocessing filters)
 - **Size extraction & visualization** (histograms, plots, CSV export)
 - **Flexible particle filtering** with `--min-size` and `--max-size` (removes noise and false detections)
@@ -505,6 +506,28 @@ python3 nanopsd.py --mode batch --input ./images --algo classical --min-size 3 -
 - If images have different magnifications, process them in separate batches with different `--nm-per-pixel` values
 - For mixed magnifications with scale bars, use `--ocr-backend` (auto-detection) instead
 
+### Optional: Interactive ROI Selection
+
+If you only want to analyze a **portion** of an image (for example, to exclude artifacts, text overlays, or a second magnification panel), add `--interactive-roi`:
+
+```
+python3 nanopsd.py --mode single --input sample_image_1.tif --algo classical \
+    --min-size 3 --scale-bar-nm 200 --interactive-roi
+```
+
+An OpenCV window opens for each image. Drag a rectangle with the mouse, then:
+
+- Press **ENTER** or **SPACE** to confirm the selection
+- Press **ESC** (or close the window) to cancel and exit
+
+The pipeline then analyzes **only the selected region**. Output files use the original image's filename. Particle centroids in `*_nanoparticle_data.csv` are in **original-image coordinates** (not ROI-local), so they line up with the original input.
+
+**Notes:**
+- Works with all three calibration methods (`--scale-bar-nm`, `--nm-per-pixel`, `--ocr-backend`).
+- Works in batch mode (`--mode batch`), but the user is prompted for every image.
+- Overlay figures (`*_true_contours`, `*_morphology_overlay`, etc.) show the **full original image** with a yellow rectangle around the selected ROI and contours drawn only inside the ROI. Overlay files are saved as `.png` (lossless) regardless of input format.
+- **Known limitation**: legends inside overlays (e.g., the Spherical/Rod-like/Aggregate legend) are drawn inside the ROI rectangle. Moving legends to a position on the full-image canvas is a planned follow-up.
+
 ---
 
 ### Contrast Polarity Option
@@ -631,6 +654,7 @@ batch_images/
 | `--save-segmentation-steps`  | Save step-by-step segmentation images  | `--save-segmentation-steps`  | No  |
 |  `--bright-particles` | Detect bright nanoparticles on dark background | `--bright-particles` | No  |
 | `--only-morphology` | Only report results for a specific morphology type | `--only-morphology spherical` | No |
+| `--interactive-roi` | Drag a rectangle on each image to select the analysis region | `--interactive-roi` | No |
 
 \* **Must provide either `--scale-bar-nm` OR `--nm-per-pixel` (not both)**
 

--- a/nanopsd.py
+++ b/nanopsd.py
@@ -258,6 +258,8 @@ def main() -> None:
         save_preprocessing_steps=args.save_preprocessing_steps,
         save_segmentation_steps=args.save_segmentation_steps,
         bright_particles=args.bright_particles,
+        # Interactive ROI selection (optional)
+        interactive_roi=args.interactive_roi,
         # Morphology classification thresholds
         spherical_ar_max=thresholds["spherical_ar_max"],
         rodlike_ar_min=thresholds["rodlike_ar_min"],

--- a/pipeline/analyzer.py
+++ b/pipeline/analyzer.py
@@ -57,6 +57,13 @@ from utils.scale_bar import (
     detect_scale_bar,  # Main geometric detector
     detect_scale_label,  # OCR text reader
 )
+
+from utils.interactive import (
+    select_roi_interactive,
+    crop_to_cache,
+    delete_cache_file,
+)
+
 from scripts.preprocessing.clahe_filter import preprocess_image
 from scripts.segmentation.otsu_impl import OtsuSegmenter
 from scripts.analysis.size_measurement import (
@@ -143,6 +150,7 @@ class NanoparticleAnalyzer:
         save_segmentation_steps: bool = False,
         bright_particles: bool = False,
         only_morphology: str = None,
+        interactive_roi: bool = False,
         # Morphology classification thresholds
         spherical_ar_max=1.5,
         rodlike_ar_min=1.8,
@@ -227,6 +235,7 @@ class NanoparticleAnalyzer:
         self.save_segmentation_steps = save_segmentation_steps
         self.bright_particles = bright_particles
         self.only_morphology = only_morphology  # Store morphology filtering option
+        self.interactive_roi = bool(interactive_roi)  # Interactive ROI selection
 
         # Store results for batch aggregation
         self.batch_results = []  # Will hold DataFrames from each image
@@ -336,6 +345,13 @@ class NanoparticleAnalyzer:
 
             logging.info(f"Batch mode: {len(images)} images found.")
 
+            if self.interactive_roi:
+                logging.warning(
+                    "⚠️  --interactive-roi is active in batch mode. "
+                    f"You will be prompted to draw a rectangle on each of "
+                    f"the {len(images)} images."
+                )
+
             batch_start_time = time.time()  # Start batch timing
             self.individual_times = []  # Reset for this batch
 
@@ -438,6 +454,16 @@ class NanoparticleAnalyzer:
         - Logs progress messages
         - Prints OCR success/failure messages
         """
+
+        # Interactive ROI bookkeeping — set before try: so the finally block
+        # can always clean up the cache file even if an exception occurs.
+        original_img_path = img_path
+        roi_offset = (0, 0)  # (x, y) offset to add back to centroids
+        cached_crop_path = None
+        roi_norm_min = None  # intensity anchor for preprocessing (None = default)
+        roi_norm_max = None
+        roi_otsu_threshold = None  # Otsu threshold from full original image
+
         try:
             base = os.path.basename(img_path)
             logging.info(f"Processing: {base}")
@@ -541,6 +567,41 @@ class NanoparticleAnalyzer:
                 )
 
             # -----------------------------------------------------------------
+            # Step 3b (optional): Interactive ROI selection
+            # -----------------------------------------------------------------
+            # If --interactive-roi is active, ask the user to drag a rectangle
+            # on the ORIGINAL image and crop to that region. Scale bar
+            # detection has already happened on the full image above, so
+            # nm_per_pixel is already known. From here on, the pipeline will
+            # process only the cropped region. Centroids are offset back to
+            # original-image coordinates after measurement.
+            if self.interactive_roi:
+                roi = select_roi_interactive(img_path)
+                if roi is None:
+                    print("\n" + "=" * 60)
+                    print("ROI SELECTION CANCELLED - Exiting NanoPSD.")
+                    print("=" * 60 + "\n")
+                    sys.exit(2)
+
+                (
+                    cached_crop_path,
+                    roi_norm_min,
+                    roi_norm_max,
+                    roi_otsu_threshold,
+                ) = crop_to_cache(img_path, roi)
+                roi_offset = (roi[0], roi[1])
+                img_path = cached_crop_path  # pipeline processes the crop
+                logging.info(
+                    f"Interactive ROI active. Offset to apply to centroids: "
+                    f"x+={roi_offset[0]}, y+={roi_offset[1]}"
+                )
+                logging.info(
+                    f"Preprocessing will use anchored normalization "
+                    f"(min={roi_norm_min}, max={roi_norm_max}) and "
+                    f"Otsu threshold {roi_otsu_threshold:.1f} from original image"
+                )
+
+            # -----------------------------------------------------------------
             # Step 4: Preprocess image to binary mask
             # -----------------------------------------------------------------
             # Returns:
@@ -555,14 +616,29 @@ class NanoparticleAnalyzer:
                     else False
                 ),
                 bright_particles=self.bright_particles,
+                norm_min=roi_norm_min,
+                norm_max=roi_norm_max,
+                otsu_threshold=roi_otsu_threshold,
             )
 
             # -----------------------------------------------------------------
             # Step 5: Mask out scale bar region
             # -----------------------------------------------------------------
             # The scale bar would otherwise be detected as a huge "particle"
-            # We set all pixels in the bar region to False (background)
-            if bar_mask is not None:
+            # We set all pixels in the bar region to False (background).
+            #
+            # When --interactive-roi is active, the binary array is in the
+            # cropped coordinate space but bar_mask is in original-image
+            # coordinates, so they can't be combined directly. Per design,
+            # we trust the user's ROI selection — if the bar is inside the
+            # ROI they included it on purpose; if it's outside, there is
+            # nothing to mask. Skip the entire masking block.
+            if self.interactive_roi:
+                logging.info(
+                    "✓ Skipping scale-bar masking (interactive ROI — "
+                    "trusting user's selected region)"
+                )
+            elif bar_mask is not None:
                 logging.info("Excluding scale bar region from particle detection...")
                 binary = binary.copy()
                 binary[bar_mask > 0] = False
@@ -626,6 +702,7 @@ class NanoparticleAnalyzer:
             # - diameters_nm: list of floats (diameter in nm for each particle)
             # - overlay_image: annotated image with contours
             # - df: pandas DataFrame with measurements (unused here)
+
             diameters_nm, overlay_image, df = measure_particles(
                 regions,
                 labeled,
@@ -646,6 +723,42 @@ class NanoparticleAnalyzer:
             )
             logging.info(f"Measured {len(diameters_nm)} particles (post-filter).")
 
+            # If interactive ROI was active, offset centroids back to
+            # original-image coordinates so the CSV aligns with the
+            # original input, and composite the crop-sized overlays onto
+            # the full original image so users see context.
+            if self.interactive_roi and roi_offset != (0, 0):
+                stem = os.path.splitext(os.path.basename(original_img_path))[0]
+
+                # 1) Offset centroids in the CSV (if any particles were found)
+                if len(df) > 0:
+                    if "Centroid_X" in df.columns:
+                        df["Centroid_X"] = df["Centroid_X"] + roi_offset[0]
+                    if "Centroid_Y" in df.columns:
+                        df["Centroid_Y"] = df["Centroid_Y"] + roi_offset[1]
+                    csv_path = f"outputs/results/{stem}_nanoparticle_data.csv"
+                    if os.path.exists(csv_path):
+                        df.to_csv(csv_path, index=False)
+                        logging.info(
+                            f"Offset applied to centroids: +{roi_offset} "
+                            f"(rewrote {csv_path})"
+                        )
+
+                # 2) Composite each crop-sized overlay back onto a full-image
+                #    canvas with a visible ROI rectangle. Overlays produced
+                #    by measure_particles are saved to outputs/figures/ with
+                #    filenames derived from image_path (the cache .png), so
+                #    they use the .png extension from the cache. We rewrite
+                #    them here at full size with the same .png extension
+                #    (lossless, avoids JPEG artifacts around contour lines).
+                self._composite_overlays_to_full_image(
+                    original_img_path=original_img_path,
+                    stem=stem,
+                    crop_ext=os.path.splitext(cached_crop_path)[1],
+                    roi_x=roi_offset[0],
+                    roi_y=roi_offset[1],
+                )
+
             # Calculate and display processing time
             processing_time = time.time() - start_time
             logging.info(f"Image processing time: {processing_time:.2f} seconds")
@@ -653,15 +766,22 @@ class NanoparticleAnalyzer:
             # -----------------------------------------------------------------
             # Step 8: Visualize and export results
             # -----------------------------------------------------------------
+            # Use the ORIGINAL image path for downstream reporting so the
+            # LaTeX report, summary CSV, and plot titles identify the image
+            # by its original filename rather than the interactive-ROI
+            # cache file. When --interactive-roi is off, original_img_path
+            # equals img_path, so this is a no-op.
+            report_path = original_img_path
+
             # plot_results: generates histograms (overall + morphology)
-            plot_results(diameters_nm, img_path, df=df)
+            plot_results(diameters_nm, report_path, df=df)
 
             # export_to_latex: generates statistical summary table
-            export_to_latex(diameters_nm, img_path)
+            export_to_latex(diameters_nm, report_path)
 
             # Export summary CSV (SINGLE MODE ONLY)
             if not self.batch_mode:
-                export_summary_csv(diameters_nm, df, img_path)
+                export_summary_csv(diameters_nm, df, report_path)
 
             # Print morphology summary
             if len(df) > 0 and "Morphology" in df.columns:
@@ -699,6 +819,10 @@ class NanoparticleAnalyzer:
             # Catch and log any errors during processing
             # This prevents one bad image from crashing batch mode
             logging.exception(f"Error while processing {img_path}: {e}")
+        finally:
+            # Always clean up the interactive-ROI cache file, even on error
+            if cached_crop_path is not None:
+                delete_cache_file(cached_crop_path)
 
     def _generate_batch_report(self, batch_start_time) -> None:
         """
@@ -846,6 +970,114 @@ class NanoparticleAnalyzer:
                     cv2.destroyAllWindows()
                     cv2.waitKey(1)
                     return False
+
+    def _composite_overlays_to_full_image(
+        self,
+        original_img_path: str,
+        stem: str,
+        crop_ext: str,
+        roi_x: int,
+        roi_y: int,
+    ) -> None:
+        """
+        Composite crop-sized overlays onto the full original image.
+
+        For each overlay produced by measure_particles (true_contours,
+        circular_equivalent, elliptical_equivalent, all_contour_types,
+        true_circular, morphology_overlay), this method:
+          1. Reads the crop-sized overlay file from outputs/figures/
+          2. Creates a full-image canvas from the original
+          3. Pastes the crop overlay at (roi_x, roi_y)
+          4. Draws a visible rectangle around the ROI
+          5. Overwrites the overlay file with the full-image version
+
+        Only runs when --interactive-roi is active. Overlays are saved
+        with .png extension (lossless) to avoid JPEG artifacts on the
+        drawn contours.
+
+        Parameters
+        ----------
+        original_img_path : str
+            Path to the original uncropped image.
+        stem : str
+            Filename stem used for overlays (e.g. "sample_image_1").
+        crop_ext : str
+            Extension used by the crop-sized overlays (e.g. ".png").
+        roi_x, roi_y : int
+            Top-left corner of the ROI in original-image coordinates.
+        """
+        import cv2
+
+        full_gray = cv2.imread(original_img_path, cv2.IMREAD_GRAYSCALE)
+        if full_gray is None:
+            logging.warning(
+                f"Could not read original for overlay compositing: "
+                f"{original_img_path}"
+            )
+            return
+        full_bgr_base = cv2.cvtColor(full_gray, cv2.COLOR_GRAY2BGR)
+        full_h, full_w = full_gray.shape[:2]
+
+        # Yellow rectangle, thickness scaled to image size (min 3 px)
+        rect_color = (0, 255, 255)
+        rect_thickness = max(3, min(full_h, full_w) // 500)
+
+        overlay_suffixes = [
+            "true_contours",
+            "circular_equivalent",
+            "elliptical_equivalent",
+            "all_contour_types",
+            "true_circular",
+            "morphology_overlay",
+        ]
+
+        for suffix in overlay_suffixes:
+            crop_overlay_path = f"outputs/figures/{stem}_{suffix}{crop_ext}"
+            if not os.path.exists(crop_overlay_path):
+                continue
+
+            crop_overlay = cv2.imread(crop_overlay_path, cv2.IMREAD_COLOR)
+            if crop_overlay is None:
+                logging.warning(f"Could not read overlay: {crop_overlay_path}")
+                continue
+
+            ch, cw = crop_overlay.shape[:2]
+
+            # Clamp paste region to canvas bounds (defensive — should
+            # never be needed since ROI was clamped on selection, but
+            # guards against any off-by-one from downstream processing).
+            paste_w = min(cw, full_w - roi_x)
+            paste_h = min(ch, full_h - roi_y)
+            if paste_w <= 0 or paste_h <= 0:
+                logging.warning(
+                    f"Skipping overlay composite for {suffix}: "
+                    f"ROI out of bounds (roi=({roi_x},{roi_y}), "
+                    f"crop={cw}x{ch}, full={full_w}x{full_h})"
+                )
+                continue
+
+            canvas = full_bgr_base.copy()
+            canvas[roi_y:roi_y + paste_h, roi_x:roi_x + paste_w] = (
+                crop_overlay[:paste_h, :paste_w]
+            )
+
+            # Draw ROI rectangle
+            cv2.rectangle(
+                canvas,
+                (roi_x, roi_y),
+                (roi_x + paste_w, roi_y + paste_h),
+                rect_color,
+                rect_thickness,
+            )
+
+            # Overwrite the file. Keep the same extension used by the
+            # crop-sized version (which is .png from our PNG cache).
+            cv2.imwrite(crop_overlay_path, canvas)
+
+        logging.info(
+            f"Composited ROI overlays onto full image "
+            f"(ROI rect at ({roi_x},{roi_y}))"
+        )
 
     @staticmethod
     def _compute_nm_per_pixel(scale_bar_nm: float, scale_bar_px: float) -> float:

--- a/scripts/analysis/size_measurement.py
+++ b/scripts/analysis/size_measurement.py
@@ -327,7 +327,7 @@ def measure_particles(
             "Morphology": [c["morphology"] for c in centroids],
         }
     )
-    df.to_csv("outputs/results/{stem}_nanoparticle_data.csv", index=False)
+    df.to_csv(f"outputs/results/{stem}_nanoparticle_data.csv", index=False)
 
     # Return the list of diameters
     return diameters_nm, combined_img, df

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -392,6 +392,26 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )    
 
+    p.add_argument(
+        "--interactive-roi",
+        action="store_true",
+        help=(
+            "Drag a rectangle on each image to select the region of interest.\n"
+            "The analysis pipeline is unchanged; it simply processes only\n"
+            "the selected region. Particle centroid coordinates in the output\n"
+            "CSV are offset back to original-image coordinates.\n"
+            "\n"
+            "Works with all calibration methods (--scale-bar-nm, --nm-per-pixel,\n"
+            "--ocr-backend) and with both --mode single and --mode batch.\n"
+            "In batch mode the user will be prompted for every image.\n"
+            "\n"
+            "Controls:\n"
+            "  - Drag a rectangle with the mouse to select a region.\n"
+            "  - Press ENTER or SPACE to confirm.\n"
+            "  - Press ESC (or close the window) to cancel and exit."
+        ),
+    )
+
     # ============================================================================
     # Optional: Morphology Classification Thresholds
     # ============================================================================

--- a/scripts/preprocessing/clahe_filter.py
+++ b/scripts/preprocessing/clahe_filter.py
@@ -19,10 +19,12 @@
 # Import OpenCV for image processing functions
 import cv2
 import os
+import numpy as np
 
 
 def preprocess_image(
-    image_path, save_steps=False, output_dir="outputs/preprocessing_steps", bright_particles=False
+    image_path, save_steps=False, output_dir="outputs/preprocessing_steps",
+    bright_particles=False, norm_min=None, norm_max=None, otsu_threshold=None,
 ):
     """
     Preprocesses a microscopy image by enhancing contrast, smoothing, and thresholding.
@@ -35,6 +37,21 @@ def preprocess_image(
         If True, save intermediate preprocessing steps for visualization.
     output_dir : str, optional (default="outputs/preprocessing_steps")
         Directory to save intermediate images.
+    bright_particles : bool, optional (default=False)
+        If True, skip inversion (use for bright particles on dark backgrounds).
+    norm_min, norm_max : int or None, optional (default=None)
+        When both are provided, they override the automatic per-image
+        min/max used by cv2.normalize(NORM_MINMAX). Use this when
+        preprocessing a cropped region of a larger image to keep the
+        normalization consistent with the full original (prevents noise
+        amplification when extreme-intensity regions like the scale bar
+        were cropped out). When either is None, behavior is unchanged.
+    otsu_threshold : float or None, optional (default=None)
+        When provided, use this as a fixed binary threshold instead of
+        running Otsu on the image. Use this to apply a threshold computed
+        from the full original image to a cropped region, so both use the
+        same intensity cutoff. When None, Otsu runs normally on the
+        input image's own histogram (existing behavior).
 
     Returns:
     --------
@@ -57,7 +74,20 @@ def preprocess_image(
         print(f"Saved: {output_dir}/{base_name}_step1_original.png")
 
     # Step 2: Normalize to 8-bit intensity range (0-255)
-    normalized = cv2.normalize(image, None, 0, 255, cv2.NORM_MINMAX)
+    # When anchor values are provided (by interactive-ROI mode), use them so
+    # the crop is stretched using the ORIGINAL image's intensity range. This
+    # avoids amplifying noise when the crop's own min/max is narrower than
+    # the full image's.
+    if norm_min is not None and norm_max is not None and norm_max > norm_min:
+        # Linear stretch using the external anchor, clipped to [0, 255]
+        normalized = np.clip(
+            (image.astype(np.float32) - float(norm_min))
+            * 255.0 / float(norm_max - norm_min),
+            0, 255,
+        ).astype(np.uint8)
+    else:
+        # Original behavior: per-image min/max stretch
+        normalized = cv2.normalize(image, None, 0, 255, cv2.NORM_MINMAX)
 
     if save_steps:
         cv2.imwrite(f"{output_dir}/{base_name}_step2_normalized.png", normalized)
@@ -78,8 +108,17 @@ def preprocess_image(
         cv2.imwrite(f"{output_dir}/{base_name}_step4_gaussian_blur.png", blurred)
         print(f"Saved: {output_dir}/{base_name}_step4_gaussian_blur.png")
 
-    # Step 5: Apply Otsu's thresholding to binarize the image
-    _, binary = cv2.threshold(blurred, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    # Step 5: Binarize. Either use a provided threshold (from the full
+    # original image — interactive-ROI mode) or let Otsu pick one from the
+    # current image's histogram (default behavior).
+    if otsu_threshold is not None:
+        _, binary = cv2.threshold(
+            blurred, float(otsu_threshold), 255, cv2.THRESH_BINARY
+        )
+    else:
+        _, binary = cv2.threshold(
+            blurred, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+        )
 
     if save_steps:
         cv2.imwrite(f"{output_dir}/{base_name}_step5_otsu_threshold.png", binary)
@@ -95,3 +134,52 @@ def preprocess_image(
 
     # Return the binary image as a boolean array and the original normalized image
     return binary > 0, image
+
+def compute_full_image_otsu(image_path, norm_min=None, norm_max=None):
+    """
+    Run the same normalize → CLAHE → blur → Otsu sequence that
+    preprocess_image uses, but only to extract the Otsu threshold value.
+
+    Used by interactive-ROI mode to compute a threshold from the ORIGINAL
+    full image, which is then passed back into preprocess_image(crop) so
+    the crop uses the same intensity cutoff as the full image would have.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to the original full image.
+    norm_min, norm_max : int or None
+        Optional anchor values for normalization. Should typically match
+        whatever crop_to_cache computed (the full image's min/max), but
+        since this IS the full image, passing them in doesn't change
+        anything — per-image min/max would be identical. Kept for
+        symmetry with preprocess_image's signature.
+
+    Returns
+    -------
+    float or None
+        Otsu threshold value in [0, 255]. Returns None if the image
+        cannot be read.
+    """
+    image = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    if image is None:
+        return None
+
+    # Mirror preprocess_image's steps 2-4 exactly
+    if norm_min is not None and norm_max is not None and norm_max > norm_min:
+        normalized = np.clip(
+            (image.astype(np.float32) - float(norm_min))
+            * 255.0 / float(norm_max - norm_min),
+            0, 255,
+        ).astype(np.uint8)
+    else:
+        normalized = cv2.normalize(image, None, 0, 255, cv2.NORM_MINMAX)
+
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    enhanced = clahe.apply(normalized)
+    blurred = cv2.GaussianBlur(enhanced, (3, 3), 0)
+
+    thresh_val, _ = cv2.threshold(
+        blurred, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+    )
+    return float(thresh_val)

--- a/utils/interactive.py
+++ b/utils/interactive.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# NanoPSD: Automated Nanoparticle Shape Distribution Analysis
+# Copyright (C) 2026 Md Fazlul Huq
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Interactive Selection Utilities for NanoPSD
+===========================================
+
+This module provides optional, user-driven input helpers that let a user
+override automatic detection when it fails or when only part of an image
+should be analyzed.
+
+Currently provides:
+  - select_roi_interactive: drag a rectangle to select the analysis region.
+
+Design notes:
+  - Kept in a dedicated module so the main analysis pipeline never imports
+    UI code unless the user explicitly requested interactive behavior.
+  - Uses cv2.selectROI (available since OpenCV 3.0, no new dependency).
+  - On user cancel (Escape / window close with no selection), returns None
+    so the caller can decide how to exit cleanly.
+"""
+
+import logging
+import os
+from typing import Optional, Tuple
+
+import cv2
+import numpy as np
+from scripts.preprocessing.clahe_filter import compute_full_image_otsu
+
+
+# Window title shown to the user during ROI selection
+_ROI_WINDOW_TITLE = "NanoPSD - Drag a rectangle to select ROI, ENTER to confirm, ESC to cancel"
+
+
+def select_roi_interactive(
+    image_path: str,
+    max_display_dim: int = 1200,
+) -> Optional[Tuple[int, int, int, int]]:
+    """
+    Prompt the user to drag a rectangle on the image and return the ROI.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to the input image. Read from disk with cv2.imread (color).
+    max_display_dim : int, default=1200
+        If either dimension of the image exceeds this, the displayed window
+        is scaled down proportionally for convenience. The returned
+        coordinates are always in ORIGINAL image space, not the scaled
+        display space.
+
+    Returns
+    -------
+    (x, y, w, h) or None
+        Bounding box of the selected region in original-image pixel
+        coordinates. Returns None if the user cancels (Esc / window close)
+        or selects a zero-area region.
+
+    Notes
+    -----
+    - Uses cv2.selectROI which blocks until the user confirms (Enter /
+      Space) or cancels (Esc).
+    - A scaled preview is used purely so large images fit on screen; the
+      coordinates are scaled back up before returning.
+    """
+    img = cv2.imread(image_path, cv2.IMREAD_COLOR)
+    if img is None:
+        raise FileNotFoundError(f"Could not read image for ROI selection: {image_path}")
+
+    h, w = img.shape[:2]
+
+    # Scale down for display if the image is large, but keep coordinates in
+    # the ORIGINAL image space.
+    scale = 1.0
+    if max(h, w) > max_display_dim:
+        scale = max_display_dim / float(max(h, w))
+        display = cv2.resize(img, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA)
+    else:
+        display = img
+
+    print("\n" + "=" * 60)
+    print("INTERACTIVE ROI SELECTION")
+    print("=" * 60)
+    print(f"Image: {os.path.basename(image_path)}  ({w} x {h} px)")
+    print("Instructions:")
+    print("  - Drag a rectangle with the mouse to select a region.")
+    print("  - Press ENTER or SPACE to confirm.")
+    print("  - Press ESC (or close window) to cancel.")
+    print("=" * 60 + "\n")
+
+    cv2.namedWindow(_ROI_WINDOW_TITLE, cv2.WINDOW_AUTOSIZE)
+    try:
+        # showCrosshair=True gives the user visible guide lines while dragging
+        # fromCenter=False means the first click is a corner, not the center
+        rx, ry, rw, rh = cv2.selectROI(
+            _ROI_WINDOW_TITLE, display, showCrosshair=True, fromCenter=False
+        )
+    finally:
+        cv2.destroyWindow(_ROI_WINDOW_TITLE)
+        # Small pump so the window actually closes on some platforms
+        cv2.waitKey(1)
+
+    # User cancelled or drew a zero-area box
+    if rw <= 0 or rh <= 0:
+        logging.info("ROI selection cancelled or empty.")
+        return None
+
+    # Scale coordinates back to original image space if we scaled the display
+    if scale != 1.0:
+        rx = int(round(rx / scale))
+        ry = int(round(ry / scale))
+        rw = int(round(rw / scale))
+        rh = int(round(rh / scale))
+
+    # Clamp to image bounds (defensive)
+    rx = max(0, min(rx, w - 1))
+    ry = max(0, min(ry, h - 1))
+    rw = max(1, min(rw, w - rx))
+    rh = max(1, min(rh, h - ry))
+
+    logging.info(
+        f"ROI selected: x={rx}, y={ry}, w={rw}, h={rh} "
+        f"(image size {w}x{h})"
+    )
+    return (rx, ry, rw, rh)
+
+
+def crop_to_cache(
+    image_path: str,
+    roi: Tuple[int, int, int, int],
+    cache_dir: str = "outputs/.cache",
+) -> Tuple[str, int, int, float]:
+    """
+    Crop an image to the given ROI and save to a cache file that preserves
+    the original stem, so downstream output filenames are unchanged.
+
+    Also returns the ORIGINAL full image's grayscale min/max intensity, so
+    the preprocessing stage can normalize the crop using the same intensity
+    range as the full image. This prevents noise amplification when the
+    crop's own min/max is narrower than the full image's (e.g., when the
+    user crops out the pure-black scale bar region).
+
+    The cache file is ALWAYS saved as PNG (lossless), regardless of the
+    input format. JPEG re-compression introduces 8x8 blocking artifacts
+    that cause Otsu thresholding to produce thousands of spurious regions.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to the original image.
+    roi : (x, y, w, h)
+        Bounding box to crop.
+    cache_dir : str
+        Directory for the temporary cropped image.
+
+    Returns
+    -------
+    (out_path, orig_min, orig_max, orig_otsu)
+        out_path : str
+            Path to the cached cropped image (always .png).
+        orig_min : int
+            Minimum grayscale intensity of the full original image (0-255).
+        orig_max : int
+            Maximum grayscale intensity of the full original image (0-255).
+        orig_otsu : float
+            Otsu binary threshold computed on the full original image
+            (after normalize → CLAHE → blur). Used to keep the crop's
+            thresholding consistent with the full image.
+    """
+    img = cv2.imread(image_path, cv2.IMREAD_UNCHANGED)
+    if img is None:
+        raise FileNotFoundError(f"Could not read image for cropping: {image_path}")
+
+    # Compute min/max from the ORIGINAL full image in grayscale space, matching
+    # what preprocess_image will see when it reads the image with IMREAD_GRAYSCALE.
+    # Preprocessing will use these as the normalization anchor so the cropped
+    # image is stretched using the full image's intensity range, preventing
+    # noise amplification when the crop's own min/max is narrower.
+    gray = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    if gray is None:
+        orig_min, orig_max = 0, 255  # safe fallback
+    else:
+        orig_min = int(np.min(gray))
+        orig_max = int(np.max(gray))
+
+    x, y, w, h = roi
+    cropped = img[y:y + h, x:x + w]
+
+    os.makedirs(cache_dir, exist_ok=True)
+    # Force PNG extension to avoid lossy re-encoding (especially for JPEG input).
+    # JPEG re-compression introduces 8x8 blocking artifacts that cause Otsu
+    # thresholding to produce thousands of spurious regions.
+    stem = os.path.splitext(os.path.basename(image_path))[0]
+    out_path = os.path.join(cache_dir, stem + ".png")
+    cv2.imwrite(out_path, cropped)
+    # Compute Otsu threshold on the FULL original image so the crop can
+    # use the same binary cutoff. This keeps segmentation behavior
+    # consistent between full-image and cropped-image runs.
+    orig_otsu = compute_full_image_otsu(image_path, norm_min=orig_min, norm_max=orig_max)
+    if orig_otsu is None:
+        orig_otsu = 127.0  # safe fallback
+
+    logging.info(
+        f"Cached cropped ROI to: {out_path} "
+        f"(original intensity range: {orig_min}-{orig_max}, "
+        f"original Otsu threshold: {orig_otsu:.1f})"
+    )
+    return out_path, orig_min, orig_max, orig_otsu
+
+
+def delete_cache_file(path: str) -> None:
+    """Delete a cache file, ignoring missing-file errors."""
+    try:
+        if path and os.path.exists(path):
+            os.remove(path)
+    except OSError as e:
+        logging.warning(f"Could not delete cache file {path}: {e}")


### PR DESCRIPTION
## What this PR does
Adds a new optional `--interactive-roi` flag that lets the user drag a rectangle on each input image to select the region to analyze. Scale bar detection runs on the full original image (so calibration is always correct), then the pipeline analyzes only the user-selected region. Outputs (CSV, histograms, overlays) reflect the cropped analysis, but overlays are composited onto the full original image with a yellow ROI rectangle so users see the analyzed region in context.

## Guarantees
- **No change to default behavior.** Running existing commands without `--interactive-roi` produces identical outputs to current `main`.
- **No changes to the analysis pipeline core.** `measure_particles` and the segmenter are untouched. All integration happens in `NanoparticleAnalyzer._process_one`.
- **No new dependencies.** Uses `cv2.selectROI` (OpenCV ≥ 3.0, already required).

## Files changed
| File | Change |
|---|---|
| `utils/interactive.py` | **New** — `select_roi_interactive`, `crop_to_cache`, `delete_cache_file` |
| `scripts/preprocessing/clahe_filter.py` | New optional params (`norm_min`, `norm_max`, `otsu_threshold`) that default to existing behavior; new helper `compute_full_image_otsu` |
| `pipeline/analyzer.py` | New `interactive_roi` param; ROI prompt after scale-bar calibration; skip bar masking in ROI mode; centroid coordinate offset; full-image overlay compositing |
| `scripts/cli.py` | `--interactive-roi` flag |
| `nanopsd.py` | Thread the flag into the analyzer |
| `README.md` | Feature documentation |
| `.gitignore` | Ignore `outputs/.cache/` |

## How it works
1. **Scale bar detection runs first on the full original image.** `nm_per_pixel` is computed before ROI selection, so calibration is independent of the user's crop.
2. **User drags a rectangle.** A cv2.selectROI window opens; ENTER/SPACE confirms, ESC cancels.
3. **The crop is saved as PNG** to `outputs/.cache/<stem>.png`. PNG is used unconditionally because JPEG re-compression introduces blocking artifacts that break Otsu thresholding.
4. **Preprocessing on the crop uses intensity anchors from the original image.** `cv2.normalize(NORM_MINMAX)` and Otsu are both global operations; without anchoring, they produce very different output when the input is a crop vs the full image. The anchors keep the crop's processing consistent with a full-image run. Non-interactive runs pass `None` for these params so behavior is unchanged.
5. **Scale bar masking is skipped** in ROI mode. The bar mask is in original-image coordinates; it doesn't apply to the cropped binary. Per design, the user's ROI is trusted — if they included the bar they included it on purpose; if not, there's nothing to mask.
6. **After measurement**, centroids are offset back to original-image coordinates so the CSV aligns with the original input.
7. **Overlays are composited onto the full original image** with a yellow rectangle around the ROI, so users see analyzed particles in context. All 6 overlay files (true_contours, circular_equivalent, elliptical_equivalent, all_contour_types, true_circular, morphology_overlay) are rewritten at full size.
8. The cache file is deleted in a `finally` block (even on error).

## Known limitation (follow-up)
When compositing overlays in ROI mode, the legends drawn by `measure_particles` (in `true_circular` and `morphology_overlay`) remain inside the ROI rectangle because they were drawn onto the crop-sized canvas before compositing. Moving legends to a position on the full-image canvas is a cosmetic improvement and will be addressed in a follow-up PR.

## Testing
Verified on all three sample images:
- Regular mode (no `--interactive-roi`): region counts and output files match pre-change `main`.
- `--interactive-roi` with ~99% ROI: region count ~1647 (matches regular mode), confirming the anchored preprocessing works.
- `--interactive-roi` with ~30% ROI: correct subset of particles analyzed, overlays show full image with yellow rectangle and contours inside the ROI.
- ESC during ROI selection: exits with code 2 and a clear message, cache cleaned up.
- Batch mode `--mode batch --interactive-roi`: warning logged at startup, user prompted per image.