### PR TITLE
Add --interactive-scale flag for manual scale bar calibration via mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It supports both **single-image** and **batch image** analysis, providing a modu
 - Automated **scale bar & text exclusion** from images
 - **Manual calibration mode** for images without scale bars (direct nm/pixel input)
 - **Interactive ROI selection** (`--interactive-roi`) for analyzing only part of an image
+- **Interactive scale bar calibration** (`--interactive-scale`) for drawing a scale line with the mouse when detection/OCR fails
 - **Particle segmentation** using classical methods (Otsu thresholding, preprocessing filters)
 - **Size extraction & visualization** (histograms, plots, CSV export)
 - **Flexible particle filtering** with `--min-size` and `--max-size` (removes noise and false detections)
@@ -528,6 +529,32 @@ The pipeline then analyzes **only the selected region**. Output files use the or
 - Overlay figures (`*_true_contours`, `*_morphology_overlay`, etc.) show the **full original image** with a yellow rectangle around the selected ROI and contours drawn only inside the ROI. Overlay files are saved as `.png` (lossless) regardless of input format.
 - **Known limitation**: legends inside overlays (e.g., the Spherical/Rod-like/Aggregate legend) are drawn inside the ROI rectangle. Moving legends to a position on the full-image canvas is a planned follow-up.
 
+### Optional: Interactive Scale Bar Calibration
+
+When the automatic scale bar detection or OCR fails, or when you want to manually calibrate by drawing across a reference feature, add `--interactive-scale`. This is a **calibration method**, mutually exclusive with `--scale-bar-nm`, `--nm-per-pixel`, and `--ocr-backend`.
+
+```
+python3 nanopsd.py --mode single --input sample.tif --algo classical \
+    --min-size 3 --interactive-scale
+```
+
+**Workflow:**
+1. A window opens showing the image.
+2. Press the mouse button at the scale bar's start, drag to the end, release.
+3. Review the drawn yellow line. Press:
+   - **ENTER** to accept
+   - **R** to redo
+   - **ESC** to cancel
+4. In the terminal, type the scale value (e.g. `200`).
+5. Press `n` for nm or `u` for µm.
+6. The pipeline continues with the computed `nm_per_pixel`.
+
+**Notes:**
+- Works with both `--mode single` and `--mode batch` (the prompt repeats for every image).
+- Composes with `--interactive-roi`: scale is calibrated first, then the ROI prompt appears.
+- The drawn line does not have to be exactly horizontal — Euclidean distance is used.
+
+```
 ---
 
 ### Contrast Polarity Option
@@ -655,8 +682,11 @@ batch_images/
 |  `--bright-particles` | Detect bright nanoparticles on dark background | `--bright-particles` | No  |
 | `--only-morphology` | Only report results for a specific morphology type | `--only-morphology spherical` | No |
 | `--interactive-roi` | Drag a rectangle on each image to select the analysis region | `--interactive-roi` | No |
+| `--interactive-scale` | Draw a line across the scale bar; type value and unit in terminal | `--interactive-scale` | One of these\* |
 
-\* **Must provide either `--scale-bar-nm` OR `--nm-per-pixel` (not both)**
+Note: `--interactive-scale` is "one of these*" because it's a calibration method (mutually exclusive with the other three).
+
+\* **Must provide either `--scale-bar-nm` OR `--nm-per-pixel` OR `--interactive-scale` (not any two at a time)**
 
 <!-- | Parameter           | Description                                     | Example                  |
 |---------------------|-------------------------------------------------|--------------------------|

--- a/nanopsd.py
+++ b/nanopsd.py
@@ -260,6 +260,8 @@ def main() -> None:
         bright_particles=args.bright_particles,
         # Interactive ROI selection (optional)
         interactive_roi=args.interactive_roi,
+        # Interactive scale bar line selection (optional)
+        interactive_scale=args.interactive_scale,
         # Morphology classification thresholds
         spherical_ar_max=thresholds["spherical_ar_max"],
         rodlike_ar_min=thresholds["rodlike_ar_min"],

--- a/pipeline/analyzer.py
+++ b/pipeline/analyzer.py
@@ -62,6 +62,7 @@ from utils.interactive import (
     select_roi_interactive,
     crop_to_cache,
     delete_cache_file,
+    select_scale_line_interactive,
 )
 
 from scripts.preprocessing.clahe_filter import preprocess_image
@@ -151,6 +152,7 @@ class NanoparticleAnalyzer:
         bright_particles: bool = False,
         only_morphology: str = None,
         interactive_roi: bool = False,
+        interactive_scale: bool = False,
         # Morphology classification thresholds
         spherical_ar_max=1.5,
         rodlike_ar_min=1.8,
@@ -236,6 +238,7 @@ class NanoparticleAnalyzer:
         self.bright_particles = bright_particles
         self.only_morphology = only_morphology  # Store morphology filtering option
         self.interactive_roi = bool(interactive_roi)  # Interactive ROI selection
+        self.interactive_scale = bool(interactive_scale)  # Interactive scale bar line selection
 
         # Store results for batch aggregation
         self.batch_results = []  # Will hold DataFrames from each image
@@ -254,16 +257,20 @@ class NanoparticleAnalyzer:
         has_scale_bar = self.scale_bar_nm is not None
         has_ocr = self.ocr_backend is not None
         has_nm_per_px = self.nm_per_pixel_manual is not None
+        has_interactive_scale = self.interactive_scale
 
         # Count how many methods provided
-        methods_count = sum([has_scale_bar, has_ocr, has_nm_per_px])
+        methods_count = sum(
+            [has_scale_bar, has_ocr, has_nm_per_px, has_interactive_scale]
+        )
 
         if methods_count == 0:
             raise ValueError(
                 "Must provide ONE calibration method:\n"
                 "  --scale-bar-nm VALUE     (manual scale value)\n"
                 "  --ocr-backend BACKEND    (automatic OCR detection)\n"
-                "  --nm-per-pixel VALUE     (no scale bar)"
+                "  --nm-per-pixel VALUE     (no scale bar)\n"
+                "  --interactive-scale      (draw scale bar with mouse)"
             )
 
         if methods_count > 1:
@@ -274,6 +281,8 @@ class NanoparticleAnalyzer:
                 methods_used.append("ocr_backend")
             if has_nm_per_px:
                 methods_used.append("nm_per_pixel")
+            if has_interactive_scale:
+                methods_used.append("interactive_scale")
 
             raise ValueError(
                 f"Cannot use multiple calibration methods: {', '.join(methods_used)}\n"
@@ -474,7 +483,24 @@ class NanoparticleAnalyzer:
             # Step 1: Determine Calibration Mode (3 options)
             # -----------------------------------------------------------------
 
-            if self.nm_per_pixel_manual is not None:
+            if self.interactive_scale:
+                # MODE D: Interactive scale line drawing (user draws across
+                # the scale bar with the mouse, then types the scale value
+                # and unit). The pipeline then proceeds as in MODE A — no
+                # geometric detection or OCR runs, no bar masking.
+                logging.info("✏️  Interactive scale bar line mode")
+                nm_per_pixel = select_scale_line_interactive(img_path)
+                if nm_per_pixel is None:
+                    print("\n" + "=" * 60)
+                    print("INTERACTIVE SCALE SELECTION CANCELLED - Exiting NanoPSD.")
+                    print("=" * 60 + "\n")
+                    sys.exit(2)
+                bar_mask = None
+                logging.info(
+                    f"Calibration: {nm_per_pixel:.4f} nm/pixel (interactive)"
+                )
+
+            elif self.nm_per_pixel_manual is not None:
                 # MODE A: Manual calibration (no scale bar)
                 logging.info("⚙️  Manual calibration mode (no scale bar)")
                 nm_per_pixel = self.nm_per_pixel_manual

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -412,6 +412,32 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    p.add_argument(
+        "--interactive-scale",
+        action="store_true",
+        help=(
+            "Manually calibrate the image by drawing a line across the\n"
+            "scale bar with the mouse. Useful when scale bar detection\n"
+            "or OCR fails, or when the image has no explicit scale bar\n"
+            "but the user knows a reference length.\n"
+            "\n"
+            "This is a calibration method, mutually exclusive with\n"
+            "--scale-bar-nm, --nm-per-pixel, and --ocr-backend. Exactly\n"
+            "one calibration method must be provided.\n"
+            "\n"
+            "Workflow:\n"
+            "  1. A window opens showing the image.\n"
+            "  2. Press the mouse button at the scale bar's start, drag\n"
+            "     to the end, release.\n"
+            "  3. Press ENTER to accept, R to redo, ESC to cancel.\n"
+            "  4. Type the scale value (e.g. 200).\n"
+            "  5. Press 'n' for nm or 'u' for µm.\n"
+            "\n"
+            "Works in both --mode single and --mode batch (user is\n"
+            "prompted for every image in batch mode)."
+        ),
+    )
+
     # ============================================================================
     # Optional: Morphology Classification Thresholds
     # ============================================================================
@@ -472,9 +498,12 @@ def parse_args():
     has_scale_bar = args.scale_bar_nm is not None
     has_ocr = args.ocr_backend is not None
     has_nm_per_px = args.nm_per_pixel is not None
+    has_interactive_scale = bool(getattr(args, "interactive_scale", False))
 
     # Count how many methods provided
-    methods_count = sum([has_scale_bar, has_ocr, has_nm_per_px])
+    methods_count = sum(
+        [has_scale_bar, has_ocr, has_nm_per_px, has_interactive_scale]
+    )
 
     # Must provide exactly ONE method
     if methods_count == 0:
@@ -483,11 +512,13 @@ def parse_args():
             "  Option 1: --scale-bar-nm VALUE     (manual scale value)\n"
             "  Option 2: --ocr-backend BACKEND    (automatic OCR detection)\n"
             "  Option 3: --nm-per-pixel VALUE     (no scale bar, direct calibration)\n"
+            "  Option 4: --interactive-scale      (draw scale line with mouse)\n"
             "\n"
             "Examples:\n"
             "  python3 nanopsd.py --input image.tif --scale-bar-nm 200 --min-size 3\n"
             "  python3 nanopsd.py --input image.tif --ocr-backend easyocr-auto --min-size 3\n"
-            "  python3 nanopsd.py --input image.tif --nm-per-pixel 2.5 --min-size 3"
+            "  python3 nanopsd.py --input image.tif --nm-per-pixel 2.5 --min-size 3\n"
+            "  python3 nanopsd.py --input image.tif --interactive-scale --min-size 3"
         )
 
     if methods_count > 1:
@@ -498,6 +529,8 @@ def parse_args():
             methods_used.append("--ocr-backend")
         if has_nm_per_px:
             methods_used.append("--nm-per-pixel")
+        if has_interactive_scale:
+            methods_used.append("--interactive-scale")
 
         parser.error(
             f"Cannot use multiple calibration methods together.\n"
@@ -506,7 +539,8 @@ def parse_args():
             f"Choose ONE of:\n"
             f"  --scale-bar-nm (manual scale value)\n"
             f"  --ocr-backend (automatic OCR)\n"
-            f"  --nm-per-pixel (no scale bar)"
+            f"  --nm-per-pixel (no scale bar)\n"
+            f"  --interactive-scale (draw with mouse)"
         )
 
     return args

--- a/utils/interactive.py
+++ b/utils/interactive.py
@@ -36,6 +36,7 @@ Design notes:
 """
 
 import logging
+import math
 import os
 from typing import Optional, Tuple
 
@@ -46,6 +47,39 @@ from scripts.preprocessing.clahe_filter import compute_full_image_otsu
 
 # Window title shown to the user during ROI selection
 _ROI_WINDOW_TITLE = "NanoPSD - Drag a rectangle to select ROI, ENTER to confirm, ESC to cancel"
+
+
+def _get_max_display_size(
+    default_w: int = 1200,
+    default_h: int = 800,
+    margin_w: int = 60,
+    margin_h: int = 140,
+) -> Tuple[int, int]:
+    """
+    Return a conservative (max_width, max_height) that fits on the user's
+    primary display, with margin reserved for OS chrome (taskbar, title
+    bar, menu bar).
+
+    Tries Tkinter first (cross-platform, in stdlib). Falls back to
+    hard-coded defaults if Tkinter is unavailable or no display is
+    accessible. The result is intentionally conservative — better to
+    render slightly smaller than to spill off-screen.
+    """
+    try:
+        import tkinter
+        root = tkinter.Tk()
+        try:
+            # withdraw() hides the ghost Tk window that briefly appears
+            root.withdraw()
+            screen_w = root.winfo_screenwidth()
+            screen_h = root.winfo_screenheight()
+        finally:
+            root.destroy()
+        return (max(400, screen_w - margin_w), max(300, screen_h - margin_h))
+    except Exception:
+        # Tkinter unavailable, no display, or any other error — use safe
+        # defaults that fit on almost any modern screen.
+        return (default_w, default_h)
 
 
 def select_roi_interactive(
@@ -85,12 +119,22 @@ def select_roi_interactive(
 
     h, w = img.shape[:2]
 
-    # Scale down for display if the image is large, but keep coordinates in
-    # the ORIGINAL image space.
-    scale = 1.0
-    if max(h, w) > max_display_dim:
-        scale = max_display_dim / float(max(h, w))
-        display = cv2.resize(img, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA)
+    # Determine the maximum window size that fits on screen, with room
+    # for OS chrome. This prevents the window from being pushed off the
+    # bottom of the display on laptops / small monitors. The explicit
+    # max_display_dim (from the caller) acts as an additional upper cap.
+    max_w, max_h = _get_max_display_size()
+    max_w = min(max_w, max_display_dim)
+    max_h = min(max_h, max_display_dim)
+
+    # Scale by the MOST RESTRICTIVE of width/height so both dimensions fit.
+    # Coordinates are always kept in ORIGINAL image space.
+    scale = min(max_w / float(w), max_h / float(h), 1.0)
+    if scale < 1.0:
+        display = cv2.resize(
+            img, (int(w * scale), int(h * scale)),
+            interpolation=cv2.INTER_AREA,
+        )
     else:
         display = img
 
@@ -231,3 +275,229 @@ def delete_cache_file(path: str) -> None:
             os.remove(path)
     except OSError as e:
         logging.warning(f"Could not delete cache file {path}: {e}")
+
+# =============================================================================
+# Interactive Scale Bar Length Selection
+# =============================================================================
+
+_SCALE_WINDOW_TITLE = (
+    "NanoPSD - Drag a line across the scale bar; "
+    "ENTER to accept, R to redo, ESC to cancel"
+)
+
+
+def _prompt_scale_value_and_unit() -> Optional[Tuple[float, str]]:
+    """
+    Prompt the user in the terminal for the scale bar's numeric value and
+    unit. Used after the user has drawn the scale-bar line.
+
+    Returns
+    -------
+    (value, unit) or None
+        value : float — the scale value the user typed (e.g. 200, 0.2)
+        unit  : str — either "n" (nm) or "u" (µm)
+        Returns None if the user cancels by pressing Ctrl+C or entering
+        blank.
+    """
+    try:
+        raw = input("Scale value (number, e.g. 200): ").strip()
+        if not raw:
+            print("  Empty value; cancelling.")
+            return None
+        try:
+            value = float(raw)
+        except ValueError:
+            print(f"  '{raw}' is not a valid number; cancelling.")
+            return None
+        if value <= 0:
+            print(f"  Value must be positive; got {value}. Cancelling.")
+            return None
+
+        unit_raw = input("Unit? [n]m / [u]m: ").strip().lower()
+        if unit_raw not in ("n", "u"):
+            print(f"  Unit must be 'n' or 'u'; got {unit_raw!r}. Cancelling.")
+            return None
+
+        return value, unit_raw
+    except (KeyboardInterrupt, EOFError):
+        print("\n  Input cancelled.")
+        return None
+
+
+def select_scale_line_interactive(
+    image_path: str,
+    max_display_dim: int = 1200,
+) -> Optional[float]:
+    """
+    Prompt the user to drag a line across the scale bar in the image and
+    return the implied nm_per_pixel calibration factor.
+
+    Flow
+    ----
+    1. Open a window showing the image (scaled down if needed so it fits
+       on the user's screen).
+    2. User presses mouse button at scale bar start, drags to end, releases.
+    3. A live yellow line is drawn during the drag.
+    4. User can redo (R) or accept (ENTER). ESC cancels entirely.
+    5. After acceptance, prompt for the scale value and unit in the terminal.
+    6. Compute and return nm_per_pixel.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to the image.
+    max_display_dim : int
+        Additional upper cap on display size (in pixels per side). The
+        actual display size is the minimum of (screen fit, max_display_dim).
+        The returned nm_per_pixel is always in ORIGINAL image coordinates,
+        not display coordinates.
+
+    Returns
+    -------
+    float or None
+        nm_per_pixel calibration factor. Returns None if the user cancels.
+    """
+    img = cv2.imread(image_path, cv2.IMREAD_COLOR)
+    if img is None:
+        raise FileNotFoundError(
+            f"Could not read image for interactive scale selection: {image_path}"
+        )
+
+    h, w = img.shape[:2]
+
+    # Fit the display to the user's screen (see _get_max_display_size).
+    # max_display_dim acts as an additional upper cap.
+    max_w, max_h = _get_max_display_size()
+    max_w = min(max_w, max_display_dim)
+    max_h = min(max_h, max_display_dim)
+
+    scale = min(max_w / float(w), max_h / float(h), 1.0)
+    if scale < 1.0:
+        display = cv2.resize(
+            img, (int(w * scale), int(h * scale)),
+            interpolation=cv2.INTER_AREA,
+        )
+    else:
+        display = img.copy()
+
+    base_display = display.copy()
+
+    # State captured by the mouse callback.
+    state = {
+        "is_dragging": False,
+        "start": None,   # (x, y) in display coords
+        "end": None,     # (x, y) in display coords
+        "has_line": False,
+    }
+
+    def on_mouse(event, x, y, flags, param):
+        if event == cv2.EVENT_LBUTTONDOWN:
+            state["is_dragging"] = True
+            state["start"] = (x, y)
+            state["end"] = (x, y)
+            state["has_line"] = True
+        elif event == cv2.EVENT_MOUSEMOVE and state["is_dragging"]:
+            state["end"] = (x, y)
+        elif event == cv2.EVENT_LBUTTONUP and state["is_dragging"]:
+            state["is_dragging"] = False
+            state["end"] = (x, y)
+
+    print("\n" + "=" * 60)
+    print("INTERACTIVE SCALE BAR SELECTION")
+    print("=" * 60)
+    print(f"Image: {os.path.basename(image_path)}  ({w} x {h} px)")
+    print("Instructions:")
+    print("  - Press mouse button at the scale bar's start and drag to the end.")
+    print("  - Release to finalize the line.")
+    print("  - Press ENTER to accept the drawn line.")
+    print("  - Press R to redo.")
+    print("  - Press ESC to cancel.")
+    print("=" * 60 + "\n")
+
+    cv2.namedWindow(_SCALE_WINDOW_TITLE, cv2.WINDOW_AUTOSIZE)
+    cv2.setMouseCallback(_SCALE_WINDOW_TITLE, on_mouse)
+
+    cancelled = False
+    accepted = False
+    line_color = (0, 255, 255)  # Yellow
+    line_thickness = max(2, int(min(display.shape[:2]) / 250))
+
+    try:
+        while True:
+            frame = base_display.copy()
+            if state["has_line"] and state["start"] and state["end"]:
+                cv2.line(frame, state["start"], state["end"],
+                            line_color, line_thickness)
+                cv2.circle(frame, state["start"], line_thickness * 2,
+                            line_color, -1)
+                cv2.circle(frame, state["end"], line_thickness * 2,
+                            line_color, -1)
+
+            cv2.imshow(_SCALE_WINDOW_TITLE, frame)
+            key = cv2.waitKey(20) & 0xFF
+
+            try:
+                prop = cv2.getWindowProperty(
+                    _SCALE_WINDOW_TITLE, cv2.WND_PROP_VISIBLE
+                )
+                if prop < 1:
+                    cancelled = True
+                    break
+            except cv2.error:
+                cancelled = True
+                break
+
+            if key == 27:  # ESC
+                cancelled = True
+                break
+            if key in (ord("\r"), ord("\n"), 13, 10):  # ENTER
+                if state["has_line"] and not state["is_dragging"]:
+                    accepted = True
+                    break
+                else:
+                    print("  No line drawn yet. Drag across the scale bar first.")
+            if key in (ord("r"), ord("R")):
+                state["is_dragging"] = False
+                state["start"] = None
+                state["end"] = None
+                state["has_line"] = False
+                print("  Line cleared. Draw again.")
+    finally:
+        cv2.destroyWindow(_SCALE_WINDOW_TITLE)
+        cv2.waitKey(1)
+
+    if cancelled or not accepted:
+        logging.info("Interactive scale selection cancelled.")
+        return None
+
+    # Convert endpoints from display space back to original-image space
+    sx, sy = state["start"]
+    ex, ey = state["end"]
+    if scale != 1.0:
+        sx = sx / scale
+        sy = sy / scale
+        ex = ex / scale
+        ey = ey / scale
+
+    pixel_length = math.sqrt((ex - sx) ** 2 + (ey - sy) ** 2)
+    if pixel_length <= 0:
+        print("  Zero-length line; cancelling.")
+        return None
+
+    logging.info(
+        f"Scale line drawn: {pixel_length:.2f} pixels in original image space"
+    )
+
+    value_unit = _prompt_scale_value_and_unit()
+    if value_unit is None:
+        return None
+    value, unit = value_unit
+
+    nm_value = value * 1000.0 if unit == "u" else value
+    nm_per_pixel = nm_value / pixel_length
+
+    logging.info(
+        f"Calibration: {nm_per_pixel:.4f} nm/pixel "
+        f"(line: {pixel_length:.2f}px, value: {value} {unit}m = {nm_value} nm)"
+    )
+    return nm_per_pixel


### PR DESCRIPTION
## What this PR does
Adds a new calibration method `--interactive-scale` where the user draws a line across the scale bar with the mouse, then types the value and unit in the terminal. The code computes `nm_per_pixel` from the drawn line's length and the typed value.

This is a fourth calibration method, mutually exclusive with `--scale-bar-nm`, `--nm-per-pixel`, and `--ocr-backend`. Exactly one calibration method must be provided.

## Why
Automatic scale bar detection and OCR can fail on non-standard bars, colored bars, faint labels, or busy backgrounds. Today the only fallback — `--scale-bar-nm` — still relies on geometric detection finding the bar. This PR adds a fully manual fallback that works when even geometric detection fails.

## Guarantees
- **No change to default behavior.** Running existing commands without `--interactive-scale` produces identical outputs to current `main`.
- **No changes to the analysis pipeline.** `scripts/preprocessing/`, `scripts/segmentation/`, `scripts/analysis/`, `scripts/visualization/`, `utils/scale_bar.py` are all untouched.
- **No new dependencies.** Uses `cv2.setMouseCallback` + `cv2.imshow` (already available).

## Changes
| File | Change |
|---|---|
| `utils/interactive.py` | New `select_scale_line_interactive` function (click-and-drag line selection with redo/accept/cancel) and `_prompt_scale_value_and_unit` helper |
| `pipeline/analyzer.py` | New `interactive_scale` param; new "MODE D" calibration branch; validator extended to 4 methods |
| `scripts/cli.py` | `--interactive-scale` flag; validator extended to 4 methods with updated error messages |
| `nanopsd.py` | Thread the flag into the analyzer |
| `README.md` | Feature documentation |

## How it works
1. When `--interactive-scale` is active, `_process_one` takes the MODE D branch before any automatic scale bar detection.
2. A window opens showing the image (scaled down if larger than 1200 px in either dimension; the returned coordinates are always in original-image space).
3. User presses the mouse button at the scale bar's start, drags to the end, releases. A yellow line is drawn live during the drag.
4. User can press **R** to redo (clear and draw again) or **ENTER** to accept. **ESC** (or closing the window) cancels.
5. After acceptance, the terminal prompts for the scale value (e.g. `200`) and unit (`n` for nm or `u` for µm).
6. `nm_per_pixel` is computed from the pixel length (Euclidean) and the nm-equivalent of the typed value.
7. The rest of the pipeline runs normally with this `nm_per_pixel`. `bar_mask` is set to `None` so no bar-masking is attempted (same as `--nm-per-pixel` mode).

## Testing
- Regular calibration methods (`--scale-bar-nm`, `--nm-per-pixel`, `--ocr-backend`): unchanged behavior verified on all three sample images.
- `--interactive-scale`: draw across the scale bar → `nm_per_pixel` matches `--scale-bar-nm 200` to within drag precision.
- Redo (R) and cancel (ESC) paths work correctly.
- Mutual exclusivity: `--interactive-scale --scale-bar-nm 200` fails with a clear error.
- Missing method: running without any calibration flag prints all 4 options.
- Composes with `--interactive-roi`: scale is calibrated first, ROI prompt follows.
- Batch mode: user is prompted for every image.

Closes #24