### PR TITLE
Improve scale bar detection + fix degenerate-ellipse artifacts in overlays

### DIFF
--- a/scripts/analysis/size_measurement.py
+++ b/scripts/analysis/size_measurement.py
@@ -194,11 +194,24 @@ def measure_particles(
             cv2.circle(true_circular_img, (int(x), int(y)), int(d_px / 2), (255, 0, 255), CONTOUR_THICKNESS)
 
             # --- 3. Elliptical Equivalent Contour (in PINK) ---
+            # cv2.fitEllipse is an ill-conditioned least-squares fit on
+            # contours that are essentially collinear (1-pixel-wide strips,
+            # edge fragments). It can return degenerate ellipses with
+            # near-zero minor axes or absurdly large major axes (e.g.,
+            # ~7.7e7 px), which render as horizontal or vertical lines
+            # across the entire overlay. Reject these by requiring:
+            #   - both axes >= 1 pixel (reject near-zero)
+            #   - both axes <= 2x the contour's bounding-box diagonal
+            #     (reject axis-length explosions)
             for contour in contours:
                 if len(contour) >= 5:
                     ellipse = cv2.fitEllipse(contour)
                     (center, axes, angle) = ellipse
-                    if axes[0] > 0 and axes[1] > 0:
+                    x_bb, y_bb, cw_bb, ch_bb = cv2.boundingRect(contour)
+                    bbox_diag = (cw_bb * cw_bb + ch_bb * ch_bb) ** 0.5
+                    max_axis = max(10.0, bbox_diag * 2.0)
+                    if (axes[0] >= 1.0 and axes[1] >= 1.0
+                            and axes[0] <= max_axis and axes[1] <= max_axis):
                         cv2.ellipse(
                             elliptical_img, ellipse, (255, 0, 255), CONTOUR_THICKNESS
                         )

--- a/utils/scale_bar.py
+++ b/utils/scale_bar.py
@@ -498,7 +498,7 @@ def detect_scale_bar(
 
     for bw, contours in _threshold_and_candidates(roi):
         for cnt in contours:
-            if len(cnt) < 5:
+            if len(cnt) < 4:
                 continue
 
             x, y, cw, ch = cv2.boundingRect(cnt)
@@ -566,7 +566,7 @@ def detect_scale_bar(
         contours, _ = cv2.findContours(sat_bw, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
         for cnt in contours:
-            if len(cnt) < 4:
+            if len(cnt) < 5:
                 continue
 
             x, y, cw, ch = cv2.boundingRect(cnt)
@@ -578,7 +578,7 @@ def detect_scale_bar(
             if aspect < 2.0:
                 continue
 
-            if ch > min(200, rh * 0.2):
+            if ch > min(200, rh * 0.3):  # Max 200 pixels OR 30% of ROI height
                 continue
 
             if cw > rw * 0.7: # Wider than 70% of image width
@@ -599,21 +599,10 @@ def detect_scale_bar(
                 roi_h=rh, solidity=solidity, extent=extent, dist_edge=dist_edge,
             )
 
-            # NOTE: We use the same scoring function, but we only let saturation candidates win if they have a significantly higher score than the best grayscale candidate.
-            # bbox_full = (x + rx, y + ry, cw, ch)
+            bbox_full = (x + rx, y + ry, cw, ch)
             # bar_mask = _mask_from_bbox(img.shape, bbox_full, pad=2)
 
-            # if best is None or score > best[0] or (score == best[0] and cw > best[1]):
-            #     roi_vis = cv2.cvtColor(roi.copy(), cv2.COLOR_GRAY2BGR)
-            #     cv2.rectangle(roi_vis, (x, y), (x + cw, y + ch), (0, 255, 255), 2)
-            #     best = (score, cw, bbox_full, bar_mask, roi_vis)
-
-            # Only accept saturation candidate if it has a significantly higher score than the best grayscale candidate
-            bbox_full = (x + rx, y + ry, cw, ch)
-
-            # Use actual contour shape as mask, not rectangle.
-            # Rectangle masks over-mask when the bar is slightly rotated or
-            # has non-rectangular end caps, occluding adjacent particles.
+            # Use actual contour shape as mask, not rectangle
             bar_mask = np.zeros(img.shape[:2], dtype=np.uint8)
             cnt_shifted = cnt.copy()
             cnt_shifted[:, :, 0] += rx


### PR DESCRIPTION
## What this PR does
Two related improvements in the analysis output path:

**1. Scale bar detection improvements (`utils/scale_bar.py`)**

| # | Location | Before | After | Effect |
|---|---|---|---|---|
| 1 | Grayscale contour loop | `len(cnt) < 5` | `len(cnt) < 4` | Accept shorter bar contours |
| 2 | Saturation contour loop | `len(cnt) < 4` | `len(cnt) < 5` | Reject tiny noise contours |
| 3 | Saturation height limit | `rh * 0.2` | `rh * 0.3` | Allow taller colored bars |
| 4 | Lines 599–613 | Dead commented code | Cleaned | Cosmetic |

Ported from an older local branch where these changes allow correct detection on images that current `main` fails on.

**2. Degenerate ellipse fix (`scripts/analysis/size_measurement.py`)**

`cv2.fitEllipse` is an ill-conditioned least-squares fit on essentially collinear contours (1-pixel-wide strips, edge fragments from segmentation noise). It can return degenerate ellipses like:
- `axes = (3.05e-18, 1.0)` (near-zero minor axis)
- `axes = (1.0, 77490640.0)` (major axis explosion)

The existing check `if axes[0] > 0 and axes[1] > 0:` only rejects **exact** zeros, letting these through. They render as horizontal/vertical lines across `_elliptical_equivalent` and `_all_contour_types` overlays.

Tighten the check to require:
- Both axes ≥ 1.0 px
- Both axes ≤ 2× the contour's bounding-box diagonal

Empirical counts on current main:

| Image | Ellipses drawn | Degenerate (now rejected) |
|---|---|---|
| `sample_image_1.jpg` | 1162 | 27 |
| `sample_image_2.tif` | 1148 | 25 |
| `sample_image_3.png` | 163 | 0 |

Sample 3's overlay is byte-identical after this fix — no degenerate ellipses to reject there, which matches the user's observation that only samples 1 & 2 showed the line artifacts.

## Guarantees
- Only two files touched
- No API changes
- No changes to the analysis pipeline, interactive features, or measurement logic
- Particle count, CSV output, histograms, and non-ellipse overlays all unchanged
- Sample 3 produces byte-identical output

## Why keep the code-direction inconsistency? (Edits 4.1 vs 4.2)
Edit 4.1 loosens contour length for grayscale detection; Edit 4.2 tightens it for the saturation path. These are different code paths with different noise characteristics: grayscale thresholding tends to produce clean contours with legitimate short bars (hence more permissive), while the HSV-saturation channel often produces small noise contours that aren't real scale bars (hence stricter). Not a typo — each direction is intentional.

## Testing
- Visual inspection: line artifacts gone from sample 1 and 2 overlays
- Sample 3: byte-identical overlays before and after
- Regression: all 3 sample images still analyze successfully with unchanged particle counts
- Target: user-provided test images that previously failed scale-bar detection now detect correctly
- `--interactive-roi` and `--interactive-scale` still work

Closes #26 