### PR TITLE
Add --threshold adaptive for local adaptive Gaussian thresholding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It supports both **single-image** and **batch image** analysis, providing a modu
 - **Manual calibration mode** for images without scale bars (direct nm/pixel input)
 - **Interactive ROI selection** (`--interactive-roi`) for analyzing only part of an image
 - **Interactive scale bar calibration** (`--interactive-scale`) for drawing a scale line with the mouse when detection/OCR fails
-- **Manual threshold override** (`--threshold VALUE`) for images where Otsu fails (e.g., small dark particles among large bright features)
+- **Manual and adaptive thresholding** (`--threshold VALUE` or `--threshold adaptive`) for images where Otsu fails (e.g., small dark particles among large bright features, or images with uneven lighting)
 - **Particle segmentation** using classical methods (Otsu thresholding, preprocessing filters)
 - **Size extraction & visualization** (histograms, plots, CSV export)
 - **Flexible particle filtering** with `--min-size` and `--max-size` (removes noise and false detections)
@@ -142,8 +142,7 @@ NanoPSD/
     │   ├── {image}_circular_equivalent.{ext}        # Circular equivalent contours
     │   ├── {image}_elliptical_equivalent.{ext}      # Elliptical fit contours
     │   ├── {image}_all_contour_types.{ext}          # Combined contour comparison
-    │    ── {image_name}_true_circular.{ext}         # True contour and circular equivalent combined
-    │   ├── {image_name}_morphology_overlay.{ext}    # Morphology classification overlayed
+    │   ├── {image_name}_true_circular.{ext}         # True contour and circular equivalent combined
     │   │
     │   └── # Batch Mode Outputs:
     │       ├── batch_boxplot_comparison.png          # Size distribution box plots
@@ -212,9 +211,6 @@ NanoPSD/
     ├── requirements.txt
     └── imglab_environment.yml
 ```
-
----
-
 ---
 
 ## Morphology Classification
@@ -558,22 +554,27 @@ python3 nanopsd.py --mode single --input sample.tif --algo classical \
 ```
 ---
 
-### Optional: Manual Threshold Override
+### Optional: Threshold Override (Manual or Adaptive)
 
 By default, NanoPSD uses **Otsu's automatic thresholding** to decide which pixels are particles and which are background. Otsu works well when particles and background are balanced populations (~20–50% particles). It **fails** when:
 
 - Particles are a tiny minority class (<1% of pixels) — e.g., small dark specks between large bright features like mask holes or structural patterns
 - The image has three or more intensity classes, and the wrong pair dominates the histogram
+- Illumination is uneven across the image (vignetting, gradient lighting)
 - You have a known-good threshold from another tool (ImageJ, Fiji) that you want to reuse
 
-For these cases, use `--threshold VALUE` to override Otsu with a specific threshold value (0–255):
+For these cases, use `--threshold` to override Otsu. The flag accepts **two kinds of arguments**:
+
+#### Option 1: Manual Threshold — `--threshold VALUE`
+
+A fixed numeric threshold (0–255) applied to every pixel:
 
 ```bash
 python3 nanopsd.py --mode single --input image.tif --algo classical \
     --min-size 50 --scale-bar-nm 200 --threshold 40
 ```
 
-**How to pick a threshold value:**
+**How to pick a value:**
 
 1. Open the image in an image viewer that shows pixel intensities (ImageJ, Fiji, or similar).
 2. Hover over a typical particle — note its intensity.
@@ -582,13 +583,47 @@ python3 nanopsd.py --mode single --input image.tif --algo classical \
 
 **Example:** If particles are around 20–30 and background is around 70, try `--threshold 40`. Adjust if you get too many false positives (lower) or miss real particles (raise).
 
-**Behavior:**
-- Pixels **darker than** `VALUE` become foreground (default dark-particle mode)
-- With `--bright-particles`, pixels **brighter than** `VALUE` become foreground
-- CLAHE and intensity normalization are **skipped** when `--threshold` is active — the value you pass applies directly to the original image pixels, so the threshold you see in ImageJ matches the threshold you pass to NanoPSD
-- Composes with `--interactive-roi` (threshold is applied inside the ROI), `--bright-particles`, `--min-size`, `--max-size`, and all calibration methods
+#### Option 2: Adaptive Threshold — `--threshold adaptive`
 
-**Tip:** Manual threshold often detects many small noise blobs. Combine with `--min-size 30` (or higher) to filter them out:
+Each pixel is compared against the mean of its local neighborhood. No single value to pick — handles uneven lighting automatically:
+
+```bash
+python3 nanopsd.py --mode single --input image.tif --algo classical \
+    --min-size 50 --scale-bar-nm 200 --threshold adaptive
+```
+
+**Tuning (optional):**
+
+```bash
+# Use a larger neighborhood (averages over more pixels)
+python3 nanopsd.py --mode single --input image.tif --algo classical \
+    --min-size 50 --scale-bar-nm 200 \
+    --threshold adaptive --adaptive-block-size 101 --adaptive-c 10
+```
+
+| Flag | Default | Effect |
+|---|---|---|
+| `--adaptive-block-size` | 51 | Neighborhood size. Must be odd integer ≥ 3. Larger = less responsive to small features. |
+| `--adaptive-c` | 15 | Constant subtracted from the local mean. Larger = more conservative (fewer blobs). Typical: 5–25. |
+
+**Important limitation of adaptive mode:** adaptive thresholding finds **local deviations**. It works well for detecting small bright or dark features, but **not for detecting large uniform regions**. If you need to detect big bright features (e.g., the interiors of large circles), use `--threshold VALUE` instead.
+
+#### When to use each option
+
+| Situation | Recommended |
+|---|---|
+| Known particle intensity range from ImageJ/Fiji | `--threshold VALUE` |
+| Uneven illumination across the image | `--threshold adaptive` |
+| Images with 3+ intensity classes | Try both — adaptive often works without tuning |
+| Detecting large uniform bright/dark regions | `--threshold VALUE` (adaptive won't see interiors) |
+| Multiple images from the same microscope | `--threshold VALUE` for consistency, or `--threshold adaptive` for robustness |
+
+#### Behavior common to both options
+
+- `--bright-particles` inverts detection direction (bright pixels become foreground) for both manual and adaptive modes
+- CLAHE and intensity normalization are **skipped** in both modes — the override is applied to the raw image (after a light Gaussian blur to reduce noise)
+- Composes with `--interactive-roi` (threshold is applied inside the ROI), `--min-size`, `--max-size`, and all calibration methods
+- Size filters matter: both overrides often produce many small blobs. Combine with `--min-size 30` (or higher) to filter noise:
 
 ```bash
 python3 nanopsd.py --mode single --input image.tif --algo classical \
@@ -723,7 +758,9 @@ batch_images/
 | `--only-morphology` | Only report results for a specific morphology type | `--only-morphology spherical` | No |
 | `--interactive-roi` | Drag a rectangle on each image to select the analysis region | `--interactive-roi` | No |
 | `--interactive-scale` | Draw a line across the scale bar; type value and unit in terminal | `--interactive-scale` | One of these\* |
-| `--threshold`       | Manual segmentation threshold (0-255); overrides Otsu            | `--threshold 40`         | No       |
+| `--threshold`         | Segmentation threshold override: numeric (0-255) or `adaptive`   | `--threshold 40` or `--threshold adaptive` | No       |
+| `--adaptive-block-size` | Block size for adaptive threshold (odd, ≥3); used with `--threshold adaptive` | `--adaptive-block-size 101` | No       |
+| `--adaptive-c`        | Constant C for adaptive threshold; used with `--threshold adaptive` | `--adaptive-c 10`        | No       |
 
 Note: `--interactive-scale` is "one of these*" because it's a calibration method (mutually exclusive with the other three).
 
@@ -1024,7 +1061,6 @@ Aggregate   :  327 ( 86.7%)  Avg:  13.61 nm
 4. **Use GPU** if available for EasyOCR
 
 ---
-````markdown
 ### Problem: Poor particle detection / segmentation
 
 **Potential issues:**
@@ -1039,13 +1075,15 @@ Aggregate   :  327 ( 86.7%)  Avg:  13.61 nm
    python3 nanopsd.py --mode single --input image.tif --scale-bar-nm 200 --min-size 3 --max-size 200
 ```
 
-6. **Otsu picks the wrong threshold**: If your image has a minority-class of particles (e.g., small dark spots between large bright features), Otsu's automatic threshold misses them. Use `--threshold VALUE` to manually set the threshold (see the "Manual Threshold Override" section above):
+6. **Otsu picks the wrong threshold**: If your image has a minority-class of particles (e.g., small dark spots between large bright features), or uneven lighting, Otsu's automatic threshold misses particles. Use `--threshold` to override it (see the "Threshold Override" section above):
 
 ```bash
-   # Override Otsu with a manual threshold
+   # Manual: you know a good threshold value
    python3 nanopsd.py --mode single --input image.tif --scale-bar-nm 200 --min-size 50 --threshold 40
+
+   # Adaptive: works without needing to pick a value; handles uneven lighting
+   python3 nanopsd.py --mode single --input image.tif --scale-bar-nm 200 --min-size 50 --threshold adaptive
 ```
-````
 
 ### Problem: Images don't have scale bars
 

--- a/nanopsd.py
+++ b/nanopsd.py
@@ -262,6 +262,19 @@ def main() -> None:
         interactive_roi=args.interactive_roi,
         # Interactive scale bar line selection (optional)
         interactive_scale=args.interactive_scale,
+        # Segmentation threshold overrides (optional).
+        # args.threshold is either None, a float (manual), or "adaptive"
+        # after CLI validation.
+        manual_threshold=(
+            args.threshold if isinstance(args.threshold, float) else None
+        ),
+        adaptive_threshold=(args.threshold == "adaptive"),
+        adaptive_block_size=(
+            args.adaptive_block_size if args.adaptive_block_size is not None else 51
+        ),
+        adaptive_c=(
+            args.adaptive_c if args.adaptive_c is not None else 15
+        ),
         # Morphology classification thresholds
         spherical_ar_max=thresholds["spherical_ar_max"],
         rodlike_ar_min=thresholds["rodlike_ar_min"],

--- a/pipeline/analyzer.py
+++ b/pipeline/analyzer.py
@@ -154,6 +154,9 @@ class NanoparticleAnalyzer:
         interactive_roi: bool = False,
         interactive_scale: bool = False,
         manual_threshold: float = None,
+        adaptive_threshold: bool = False,
+        adaptive_block_size: int = 51,
+        adaptive_c: int = 15,
         # Morphology classification thresholds
         spherical_ar_max=1.5,
         rodlike_ar_min=1.8,
@@ -241,6 +244,9 @@ class NanoparticleAnalyzer:
         self.interactive_roi = bool(interactive_roi)  # Interactive ROI selection
         self.interactive_scale = bool(interactive_scale)  # Interactive scale bar line selection
         self.manual_threshold = manual_threshold  # Manual threshold value (--threshold); None = use Otsu
+        self.adaptive_threshold = bool(adaptive_threshold)  # Use adaptive thresholding instead of Otsu
+        self.adaptive_block_size = int(adaptive_block_size)  # Block size for adaptive thresholding
+        self.adaptive_c = int(adaptive_c)  # C constant for adaptive thresholding
 
         # Store results for batch aggregation
         self.batch_results = []  # Will hold DataFrames from each image
@@ -636,12 +642,30 @@ class NanoparticleAnalyzer:
             # - binary: boolean array (True = particle, False = background)
             # - original: grayscale image (for overlay visualization later)
             # binary, original = preprocess_image(img_path)
-            # If manual_threshold is provided (--threshold), it short-circuits
-            # the preprocessing pipeline and takes precedence over the ROI-mode
-            # Otsu anchor. Intensity normalization anchors (norm_min/norm_max)
-            # aren't used either, because manual threshold is applied to the
-            # raw image.
-            if self.manual_threshold is not None:
+            # Dispatch to the appropriate preprocessing path based on
+            # which threshold override (if any) the user provided:
+            #   1. --threshold adaptive  -> adaptive Gaussian thresholding
+            #   2. --threshold VALUE     -> manual fixed threshold
+            #   3. (default)             -> CLAHE + Otsu, with optional
+            #                               ROI-mode normalization/Otsu anchors
+            if self.adaptive_threshold:
+                binary, original = preprocess_image(
+                    img_path,
+                    save_steps=(
+                        self.save_preprocessing_steps
+                        if hasattr(self, "save_preprocessing_steps")
+                        else False
+                    ),
+                    bright_particles=self.bright_particles,
+                    adaptive_threshold=True,
+                    adaptive_block_size=self.adaptive_block_size,
+                    adaptive_c=self.adaptive_c,
+                )
+                logging.info(
+                    f"Adaptive threshold mode: block_size={self.adaptive_block_size}, "
+                    f"C={self.adaptive_c} (Otsu, CLAHE, and normalization skipped)"
+                )
+            elif self.manual_threshold is not None:
                 binary, original = preprocess_image(
                     img_path,
                     save_steps=(

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -376,27 +376,65 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="VALUE",
         help=(
-            "Manual segmentation threshold override.\n"
+            "Segmentation threshold override.\n"
             "\n"
-            "Accepts a numeric value between 0 and 255. Pixels darker than\n"
-            "this value become foreground (in default dark-particle mode);\n"
-            "brighter pixels become foreground when --bright-particles is\n"
-            "active. This REPLACES Otsu's automatic threshold selection.\n"
+            "Accepts either:\n"
+            "  - A numeric value 0-255 (manual threshold)\n"
+            "  - The keyword 'adaptive' (local adaptive thresholding)\n"
+            "\n"
+            "Both REPLACE Otsu's automatic threshold selection.\n"
+            "\n"
+            "Manual threshold (--threshold 40):\n"
+            "  Pixels darker than 40 become foreground (dark-particle\n"
+            "  mode). The value is applied to the ORIGINAL image — CLAHE\n"
+            "  and normalization are skipped so the value you pass\n"
+            "  matches pixel values in ImageJ/Fiji.\n"
+            "\n"
+            "Adaptive threshold (--threshold adaptive):\n"
+            "  Each pixel is compared against the mean of its local\n"
+            "  neighborhood. Handles uneven illumination and\n"
+            "  minority-class particles without needing to pick an\n"
+            "  exact value. Tune via --adaptive-block-size (default 51,\n"
+            "  must be odd) and --adaptive-c (default 15).\n"
             "\n"
             "When to use:\n"
-            "  - Otsu fails because particles are a tiny minority class\n"
-            "    (e.g., small dark specks against large bright features)\n"
-            "  - You have a known-good threshold from ImageJ/Fiji\n"
-            "  - The image has three or more intensity classes and Otsu\n"
-            "    picks the wrong boundary\n"
+            "  - Manual: you have a known-good threshold from ImageJ\n"
+            "  - Adaptive: uneven lighting or the image has more than\n"
+            "    two intensity classes (e.g., bright structural features\n"
+            "    + gray matrix + dark particles)\n"
             "\n"
-            "The value is applied to the ORIGINAL image intensity (after\n"
-            "a light Gaussian blur to reduce JPEG noise). CLAHE and\n"
-            "normalization are skipped so the threshold you pass matches\n"
-            "the pixel values you see in an image viewer.\n"
-            "\n"
-            "Example:\n"
-            "  --threshold 40    (pixels darker than 40 become foreground)"
+            "Examples:\n"
+            "  --threshold 40\n"
+            "  --threshold adaptive\n"
+            "  --threshold adaptive --adaptive-block-size 101 --adaptive-c 10"
+        ),
+    )
+
+    p.add_argument(
+        "--adaptive-block-size",
+        type=int,
+        default=None,
+        metavar="SIZE",
+        help=(
+            "Block size for adaptive thresholding (only used with\n"
+            "--threshold adaptive). Must be an odd integer >= 3.\n"
+            "Default: 51. Larger = averages over a wider area (less\n"
+            "responsive to small features); smaller = more responsive\n"
+            "but noisier."
+        ),
+    )
+
+    p.add_argument(
+        "--adaptive-c",
+        type=int,
+        default=None,
+        metavar="C",
+        help=(
+            "Constant subtracted from the local mean in adaptive\n"
+            "thresholding (only used with --threshold adaptive).\n"
+            "Default: 15. Larger = more conservative (fewer blobs);\n"
+            "smaller = more permissive (more blobs, more noise).\n"
+            "Typical range: 5-25."
         ),
     )
 
@@ -573,26 +611,49 @@ def parse_args():
             f"  --interactive-scale (draw with mouse)"
         )
 
-    # --threshold: validate and convert to a parsed form
-    # (future: will also accept the keyword "adaptive" in a follow-up PR)
+    # --threshold: validate and convert to a parsed form.
+    # Accepts either the keyword "adaptive" or a numeric value 0-255.
+    # The parsed form is either the string "adaptive" or a float.
     if args.threshold is not None:
         raw = args.threshold.strip().lower()
         if raw == "adaptive":
+            # Substitute real defaults for the sentinels, then validate
+            if args.adaptive_block_size is None:
+                args.adaptive_block_size = 51
+            if args.adaptive_c is None:
+                args.adaptive_c = 15
+            if args.adaptive_block_size < 3:
+                parser.error(
+                    f"--adaptive-block-size must be >= 3; got {args.adaptive_block_size}."
+                )
+            if args.adaptive_block_size % 2 == 0:
+                parser.error(
+                    f"--adaptive-block-size must be an ODD integer; got "
+                    f"{args.adaptive_block_size}. Try {args.adaptive_block_size + 1}."
+                )
+            args.threshold = "adaptive"
+        else:
+            try:
+                val = float(raw)
+            except ValueError:
+                parser.error(
+                    f"--threshold must be 'adaptive' or a number 0-255; "
+                    f"got {args.threshold!r}."
+                )
+            if not (0 <= val <= 255):
+                parser.error(
+                    f"--threshold must be between 0 and 255; got {val}."
+                )
+            # Replace the string with a float, for the downstream analyzer
+            args.threshold = val
+    else:
+        # If user passed adaptive tuning flags without --threshold adaptive,
+        # that's an error — the flags have no effect otherwise.
+        if args.adaptive_block_size is not None or args.adaptive_c is not None:
             parser.error(
-                "--threshold adaptive is not yet implemented. Use a numeric\n"
-                "value 0-255 for now, e.g., --threshold 40."
+                "--adaptive-block-size and --adaptive-c can only be used with\n"
+                "--threshold adaptive. Add '--threshold adaptive' to enable\n"
+                "adaptive mode, or omit these flags to use Otsu (default)."
             )
-        try:
-            val = float(raw)
-        except ValueError:
-            parser.error(
-                f"--threshold must be a number between 0 and 255; got {args.threshold!r}."
-            )
-        if not (0 <= val <= 255):
-            parser.error(
-                f"--threshold must be between 0 and 255; got {val}."
-            )
-        # Replace the string with a float, for the downstream analyzer
-        args.threshold = val
 
     return args

--- a/scripts/preprocessing/clahe_filter.py
+++ b/scripts/preprocessing/clahe_filter.py
@@ -26,6 +26,7 @@ def preprocess_image(
     image_path, save_steps=False, output_dir="outputs/preprocessing_steps",
     bright_particles=False, norm_min=None, norm_max=None, otsu_threshold=None,
     manual_threshold=None,
+    adaptive_threshold=False, adaptive_block_size=51, adaptive_c=15,
 ):
     """
     Preprocesses a microscopy image by enhancing contrast, smoothing, and thresholding.
@@ -62,6 +63,27 @@ def preprocess_image(
         Use this for images where Otsu fails, e.g., minority-class dark
         particles. When None, the normal preprocessing pipeline runs.
         Takes precedence over otsu_threshold when both are provided.
+    adaptive_threshold : bool, optional (default=False)
+        When True (via --threshold adaptive), use OpenCV's adaptive
+        Gaussian thresholding instead of Otsu. Each pixel is compared
+        against the mean of its local neighborhood (of size
+        adaptive_block_size), with adaptive_c subtracted. Good for images
+        with uneven lighting or minority-class particles where a single
+        global threshold can't capture all particles. CLAHE and
+        normalization are skipped (adaptive thresholding is already a
+        local method — double-adapting produces noise). Takes precedence
+        over both manual_threshold and otsu_threshold.
+    adaptive_block_size : int, optional (default=51)
+        Size of the local neighborhood used by adaptive thresholding.
+        Must be an odd integer >= 3. Larger values average over a wider
+        area (less responsive to small features); smaller values are
+        more responsive but can be noisier.
+    adaptive_c : int, optional (default=15)
+        Constant subtracted from the local mean before comparison.
+        Larger values make the threshold more conservative (fewer
+        pixels are marked foreground); smaller values are more
+        permissive (more pixels marked foreground, including more
+        noise). Typical range: 5-25.
 
     Returns:
     --------
@@ -82,6 +104,38 @@ def preprocess_image(
     if save_steps:
         cv2.imwrite(f"{output_dir}/{base_name}_step1_original.png", image)
         print(f"Saved: {output_dir}/{base_name}_step1_original.png")
+
+    # Short-circuit: if user provided --threshold adaptive, use OpenCV's
+    # adaptive Gaussian thresholding. Skip normalize, CLAHE, and Otsu —
+    # adaptive thresholding is ALREADY a local method, so running CLAHE
+    # before it double-adapts and amplifies matrix texture noise (verified
+    # empirically: CLAHE gave 17,456 noise blobs vs 1,263 real particles
+    # on a test image). Only a light blur + adaptiveThreshold + inversion.
+    if adaptive_threshold:
+        # Light Gaussian blur to reduce JPEG / sensor noise.
+        blurred = cv2.GaussianBlur(image, (3, 3), 0)
+        if save_steps:
+            cv2.imwrite(f"{output_dir}/{base_name}_step2_adaptive_blur.png", blurred)
+            print(f"Saved: {output_dir}/{base_name}_step2_adaptive_blur.png")
+
+        # cv2.adaptiveThreshold with THRESH_BINARY_INV means:
+        # pixels DARKER than (local_mean - C) become foreground.
+        # That's the default dark-particle case.
+        # For bright particles, use THRESH_BINARY (pixels BRIGHTER than
+        # local_mean + C become foreground) — NO post-inversion needed
+        # since the polarity is embedded in the threshold type.
+        thresh_type = (
+            cv2.THRESH_BINARY if bright_particles else cv2.THRESH_BINARY_INV
+        )
+        binary = cv2.adaptiveThreshold(
+            blurred, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C,
+            thresh_type, int(adaptive_block_size), int(adaptive_c)
+        )
+        if save_steps:
+            cv2.imwrite(f"{output_dir}/{base_name}_step3_adaptive_threshold.png", binary)
+            print(f"Saved: {output_dir}/{base_name}_step3_adaptive_threshold.png")
+
+        return binary > 0, image
 
     # Short-circuit: if user provided --threshold VALUE, skip the full
     # normalize → CLAHE → blur pipeline. Instead, apply a light blur to


### PR DESCRIPTION
## What this PR does
Enables `--threshold adaptive` (placeholder added in #<PR5> as "not yet implemented") to use OpenCV's adaptive Gaussian thresholding. Adds optional `--adaptive-block-size` and `--adaptive-c` tuning flags.

## Motivation
PR #<PR5> added manual `--threshold VALUE` for images where Otsu fails. But manual threshold assumes uniform illumination. Adaptive thresholding handles uneven illumination and doesn't require the user to pick a value.

## Defaults (empirically validated)

Swept `block_size × C` on 4 images (587px to 4096px). Chose `block_size=51, C=15`:

| Image | Default result |
|---|---|
| sample_image_1.jpg (2K×2K) | 472 blobs |
| sample_image_2.tif (2K×2K) | 470 blobs |
| sample_image_3.png (587px) | 99 blobs |
| TEM minority-class test (4K×4K) | 1,263 blobs |

## Design choices

**1. Skip CLAHE for adaptive (same rule as manual threshold).** Empirically: with CLAHE, adaptive gives 17,456 noise blobs. Without: 1,263 real blobs. Adaptive is already a local method, so CLAHE double-adapts and amplifies noise.

**2. `--bright-particles` uses `THRESH_BINARY` instead of post-inversion.** The polarity is embedded in the threshold-type flag. No post-inversion step needed.

**3. Tuning flags guarded by a validator.** `--adaptive-block-size` and `--adaptive-c` only apply with `--threshold adaptive`; otherwise they error out. Block size must be odd ≥ 3.

## Known limitation (documented in README)

Adaptive thresholding finds local deviations, so it's **not suited for detecting large uniform regions** (e.g., interiors of big bright features). Users needing that should use `--threshold VALUE` instead. Validated empirically:
- `--threshold 150 --bright-particles`: 26 bright circles detected ✓
- `--threshold adaptive --bright-particles`: only ~4 edge-region blobs detected ✗

## Guarantees
- Default behavior (no `--threshold`) unchanged
- Manual threshold from PR #<PR5> unchanged
- No new dependencies (OpenCV's `adaptiveThreshold` already imported elsewhere in the repo)
- No API breakage

## Changes
| File | Change |
|---|---|
| `scripts/preprocessing/clahe_filter.py` | New `adaptive_threshold`, `adaptive_block_size`, `adaptive_c` params; short-circuit branch before manual-threshold branch |
| `scripts/cli.py` | Extend `--threshold` to accept "adaptive"; new `--adaptive-block-size` and `--adaptive-c` flags with validation |
| `pipeline/analyzer.py` | Thread params through `_process_one` dispatch; adaptive branch takes precedence over manual |
| `nanopsd.py` | Translate `args.threshold` ("adaptive" vs float vs None) to analyzer kwargs |
| `README.md` | Features bullet, extended Threshold Override section, CLI table rows, troubleshooting entry |

## Testing
- Sample images 1–3 produce unchanged output when `--threshold` absent
- Manual threshold (PR 5) unchanged
- `--threshold adaptive`: detects dark minority-class particles
- `--adaptive-block-size 50` → "must be an ODD integer" error
- `--adaptive-block-size 1` → "must be >= 3" error
- `--adaptive-block-size 101` without `--threshold adaptive` → error
- `--threshold xyz` → "must be 'adaptive' or a number 0-255" error
- Integration: `--bright-particles` (known limitation documented), `--interactive-roi`, batch mode, all calibration methods

Closes #30